### PR TITLE
Add reuse port/address for Windows and Linux

### DIFF
--- a/lib/mdns_lite/responder.ex
+++ b/lib/mdns_lite/responder.ex
@@ -20,6 +20,7 @@ defmodule MdnsLite.Responder do
   @mdns_port 5353
   @sol_socket 0xFFFF
   @so_reuseport 0x0200
+  @so_reuseaddr 0x0004
 
   defmodule State do
     @moduledoc false
@@ -225,13 +226,33 @@ defmodule MdnsLite.Responder do
     ] ++ reuse_port()
   end
 
-  defp reuse_port() do
+  def reuse_port() do
     case :os.type() do
+      {:unix, :linux} ->
+        reuse_port_linux()
+
       {:unix, os_name} when os_name in [:darwin, :freebsd, :openbsd, :netbsd] ->
-        [{:raw, @sol_socket, @so_reuseport, <<1::native-32>>}]
+        get_reuse_port()
+
+      {:win32, _unused} ->
+        get_reuse_address()
 
       _ ->
         []
     end
   end
+
+  defp reuse_port_linux() do
+    case :os.version() do
+      {major, minor, _} when major > 3 or (major == 3 and minor >= 9) ->
+        get_reuse_port()
+
+      _before_3_9 ->
+        get_reuse_address()
+    end
+  end
+
+  defp get_reuse_port(), do: [{:raw, @sol_socket, @so_reuseport, <<1::native-32>>}]
+
+  defp get_reuse_address(), do: [{:raw, @sol_socket, @so_reuseaddr, <<1::native-32>>}]
 end

--- a/lib/mdns_lite/vintage_net_monitor.ex
+++ b/lib/mdns_lite/vintage_net_monitor.ex
@@ -1,108 +1,110 @@
-defmodule MdnsLite.VintageNetMonitor do
-  use GenServer
-  @moduledoc false
-
-  alias MdnsLite.{Responder, ResponderSupervisor}
-
-  @addresses_topic ["interface", :_, "addresses"]
-
-  defmodule State do
+if Code.ensure_loaded?(VintageNet) do
+  defmodule MdnsLite.VintageNetMonitor do
+    use GenServer
     @moduledoc false
 
-    defstruct [:excluded_ifnames, :ipv4_only, :ip_list]
-  end
+    alias MdnsLite.{Responder, ResponderSupervisor}
 
-  @spec start_link(excluded_ifnames: [String.t()], ipv4_only: boolean()) :: GenServer.on_start()
-  def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
-  end
+    @addresses_topic ["interface", :_, "addresses"]
 
-  @impl true
-  def init(opts) do
-    excluded_ifnames =
-      Keyword.get(opts, :excluded_ifnames, [])
-      |> Enum.map(&to_string/1)
+    defmodule State do
+      @moduledoc false
 
-    ipv4_only = Keyword.get(opts, :ipv4_only, true)
+      defstruct [:excluded_ifnames, :ipv4_only, :ip_list]
+    end
 
-    state = %State{
-      excluded_ifnames: excluded_ifnames,
-      ip_list: MapSet.new(),
-      ipv4_only: ipv4_only
-    }
+    @spec start_link(excluded_ifnames: [String.t()], ipv4_only: boolean()) :: GenServer.on_start()
+    def start_link(opts \\ []) do
+      GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    end
 
-    _ = VintageNet.subscribe(@addresses_topic)
+    @impl true
+    def init(opts) do
+      excluded_ifnames =
+        Keyword.get(opts, :excluded_ifnames, [])
+        |> Enum.map(&to_string/1)
 
-    {:ok, state, {:continue, :initialization}}
-  end
+      ipv4_only = Keyword.get(opts, :ipv4_only, true)
 
-  @impl true
-  def handle_continue(:initialization, state) do
-    address_data =
-      VintageNet.match(@addresses_topic)
-      |> Stream.filter(&allowed_interface?(&1, state))
-      |> Enum.map(&elem(&1, 1))
-      |> List.flatten()
+      state = %State{
+        excluded_ifnames: excluded_ifnames,
+        ip_list: MapSet.new(),
+        ipv4_only: ipv4_only
+      }
 
-    {:noreply, add_ips(state, address_data)}
-  end
+      _ = VintageNet.subscribe(@addresses_topic)
 
-  @impl true
-  def handle_info({VintageNet, ["interface", ifname, "addresses"], old, new, _}, state) do
-    new_state =
-      if allowed_interface?(ifname, state) do
-        state
-        |> remove_ips(old)
-        |> add_ips(new)
-      else
-        state
-      end
+      {:ok, state, {:continue, :initialization}}
+    end
 
-    {:noreply, new_state}
-  end
+    @impl true
+    def handle_continue(:initialization, state) do
+      address_data =
+        VintageNet.match(@addresses_topic)
+        |> Stream.filter(&allowed_interface?(&1, state))
+        |> Enum.map(&elem(&1, 1))
+        |> List.flatten()
 
-  defp add_ips(state, nil), do: state
+      {:noreply, add_ips(state, address_data)}
+    end
 
-  defp add_ips(%{ip_list: ip_list} = state, address_data) do
-    ip_list =
-      fetch_ips(address_data)
-      |> filter_by_ipv4(state.ipv4_only)
-      |> Enum.reduce(ip_list, fn ip, acc ->
-        _ = ResponderSupervisor.start_child(ip)
-        MapSet.put(acc, ip)
-      end)
+    @impl true
+    def handle_info({VintageNet, ["interface", ifname, "addresses"], old, new, _}, state) do
+      new_state =
+        if allowed_interface?(ifname, state) do
+          state
+          |> remove_ips(old)
+          |> add_ips(new)
+        else
+          state
+        end
 
-    %{state | ip_list: ip_list}
-  end
+      {:noreply, new_state}
+    end
 
-  defp allowed_interface?({["interface", ifname, _], _}, state) do
-    allowed_interface?(ifname, state)
-  end
+    defp add_ips(state, nil), do: state
 
-  defp allowed_interface?(ifname, %{excluded_ifnames: excluded_ifnames}) do
-    ifname not in excluded_ifnames
-  end
+    defp add_ips(%{ip_list: ip_list} = state, address_data) do
+      ip_list =
+        fetch_ips(address_data)
+        |> filter_by_ipv4(state.ipv4_only)
+        |> Enum.reduce(ip_list, fn ip, acc ->
+          _ = ResponderSupervisor.start_child(ip)
+          MapSet.put(acc, ip)
+        end)
 
-  defp fetch_ips(ip_list), do: Enum.map(ip_list, & &1.address)
+      %{state | ip_list: ip_list}
+    end
 
-  defp filter_by_ipv4(ip_list, false) do
-    ip_list
-  end
+    defp allowed_interface?({["interface", ifname, _], _}, state) do
+      allowed_interface?(ifname, state)
+    end
 
-  defp filter_by_ipv4(ip_list, true) do
-    Enum.filter(ip_list, &(MdnsLite.Utilities.ip_family(&1) == :inet))
-  end
+    defp allowed_interface?(ifname, %{excluded_ifnames: excluded_ifnames}) do
+      ifname not in excluded_ifnames
+    end
 
-  defp remove_ips(state, nil), do: state
+    defp fetch_ips(ip_list), do: Enum.map(ip_list, & &1.address)
 
-  defp remove_ips(%{ip_list: ip_list} = state, address_data) do
-    ip_list =
-      fetch_ips(address_data)
-      |> Enum.reduce(ip_list, fn ip, acc ->
-        _ = Responder.stop_server(ip)
-        MapSet.delete(acc, ip)
-      end)
+    defp filter_by_ipv4(ip_list, false) do
+      ip_list
+    end
 
-    %{state | ip_list: ip_list}
+    defp filter_by_ipv4(ip_list, true) do
+      Enum.filter(ip_list, &(MdnsLite.Utilities.ip_family(&1) == :inet))
+    end
+
+    defp remove_ips(state, nil), do: state
+
+    defp remove_ips(%{ip_list: ip_list} = state, address_data) do
+      ip_list =
+        fetch_ips(address_data)
+        |> Enum.reduce(ip_list, fn ip, acc ->
+          _ = Responder.stop_server(ip)
+          MapSet.delete(acc, ip)
+        end)
+
+      %{state | ip_list: ip_list}
+    end
   end
 end


### PR DESCRIPTION
Add OS-specific port reuse handling for Windows sockets. Also add port reuse for Linux, which supports different options depending on the kernel version.
This avoids :eaddrinuse errors that occur nearly all the time in Windows, and sometimes in Linux.

Also a minor fix, when a client of mdns_lite does not use the optional VintageNetMonitor, there are warnings like this:
```
warning: VintageNet.match/1 is undefined (module VintageNet is not available or is yet to be defined)
  lib/mdns_lite/vintage_net_monitor.ex:42: MdnsLite.VintageNetMonitor.handle_continue/2
```
A Code.ensure_loaded? check gets rid of the warnings for the optional code.
