### PR TITLE
Remove responder on localhost and excluded ifnames

### DIFF
--- a/lib/mdns_lite/vintage_net_monitor.ex
+++ b/lib/mdns_lite/vintage_net_monitor.ex
@@ -40,7 +40,9 @@ defmodule MdnsLite.VintageNetMonitor do
   def handle_continue(:initialization, state) do
     address_data =
       VintageNet.match(@addresses_topic)
-      |> Stream.filter(&allowed_interface?(&1, state))
+      |> Enum.filter(fn {["interface", ifname, "addresses"], _} ->
+        allowed_interface?(ifname, state)
+      end)
       |> Enum.map(&elem(&1, 1))
       |> List.flatten()
 


### PR DESCRIPTION
This was due to a bug in how addresses were being processed from
VintageNet. The result was that mDNS responses could be sent with
127.0.0.1 when localhost was included. Luckily, it appears that those
were generally ignored by clients, but mdns_lite shouldn't do that.
