### PR TITLE
Various cleanup from large refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A typical configuration in the `config.exs` file looks like:
 ```elixir
 config :mdns_lite,
   # Advertise `hostname.local` on the LAN
-  host: :hostname,
+  hosts: [:hostname],
   services: [
     # Advertise an HTTP server running on port 80
     %{

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,7 @@ config :mdns_lite,
   # value of :inet.gethostname() or a string and hostname2 is a string value.
   # Example: [:hostname, "nerves"]
 
-  host: [:hostname, "nerves"],
+  hosts: [:hostname, "nerves"],
   ttl: 120,
 
   # A list of this host's services. NB: There are two other mDNS values: weight

--- a/lib/mdns_lite.ex
+++ b/lib/mdns_lite.ex
@@ -66,22 +66,25 @@ defmodule MdnsLite do
   @doc """
   Set the list of host names
 
-  `host` can have the value of  `:hostname` in which case the value will be
-  replaced with the value of `:inet.gethostname()`, otherwise you can provide a
-  string value. You can specify an alias hostname in which case `host` will be
-  `["hostname", "alias-example"]`. The second value must be a string. When you
-  use an alias, an "A" query can be made to  `alias-example.local` as well as
-  to `hostname.local`. This can also be configured at runtime via
-  `MdnsLite.set_host/1`:
+  This replaces the list of hostnames that MdnsLite will respond to. The first
+  hostname in the list is special. Service advertisements will use it. The
+  remainder are aliases.
+
+  Hostnames should not have the ".local" extension. MdnsLite will add it.
+
+  To specify the hostname returned by `:inet.gethostname/0`, use `:hostname`.
+
+  To make MdnsLite respond to queries for "<hostname>.local" and
+  "nerves.local", run this:
 
   ```elixir
-  iex> MdnsLite.set_host([:hostname, "nerves"])
+  iex> MdnsLite.set_hosts([:hostname, "nerves"])
   :ok
   ```
   """
-  @spec set_host(:hostname | String.t()) :: :ok
-  def set_host(host) do
-    TableServer.update_options(&Options.set_host(&1, host))
+  @spec set_hosts([:hostname | String.t()]) :: :ok
+  def set_hosts(hosts) do
+    TableServer.update_options(&Options.set_hosts(&1, hosts))
   end
 
   @doc """

--- a/lib/mdns_lite.ex
+++ b/lib/mdns_lite.ex
@@ -38,8 +38,8 @@ defmodule MdnsLite do
     `:protocol`, or `:type`) * `:protocol` - the application protocol. E.g.,
     `"ssh"` (specify this and `:transport`, or `:type`)
   * `:type` - the transport/protocol to advertize. E.g., `"_ssh._tcp"` (only
-    needed if `:protocol` and `:transport` aren't specified) * `:weight` - the
-    service weight. Defaults to `0`. (optional)
+    needed if `:protocol` and `:transport` aren't specified)
+  * `:weight` - the service weight. Defaults to `0`. (optional)
   * `:priority` - the service priority. Defaults to `0`. (optional)
   * `:txt_payload` - a list of strings to advertise
 

--- a/lib/mdns_lite/application.ex
+++ b/lib/mdns_lite/application.ex
@@ -5,7 +5,7 @@ defmodule MdnsLite.Application do
 
   @impl Application
   def start(_type, _args) do
-    config = MdnsLite.Options.from_application_env()
+    config = Application.get_all_env(:mdns_lite) |> MdnsLite.Options.new()
 
     children = [
       {MdnsLite.TableServer, config},

--- a/lib/mdns_lite/dns.ex
+++ b/lib/mdns_lite/dns.ex
@@ -29,7 +29,9 @@ defmodule MdnsLite.DNS do
   end
 
   def pretty(dns_rr(domain: domain, type: :txt, class: :in, ttl: ttl, data: data)) do
-    "#{domain}: type TXT, class IN, ttl #{ttl}, #{Enum.join(data, ", ")}"
+    formatted_data = if data == [], do: "", else: ", #{Enum.join(data, ", ")}"
+
+    "#{domain}: type TXT, class IN, ttl #{ttl}" <> formatted_data
   end
 
   def pretty(

--- a/lib/mdns_lite/options.ex
+++ b/lib/mdns_lite/options.ex
@@ -7,7 +7,7 @@ defmodule MdnsLite.Options do
 
   ```elixir
   config :mdns_lite,
-    host: [:hostname, "nerves"],
+    hosts: [:hostname, "nerves"],
     ttl: 120,
 
     services: [
@@ -29,7 +29,7 @@ defmodule MdnsLite.Options do
 
   The configurable keys are:
 
-  * `:host` - A list of hostnames to respond to. Normally this would be set to
+  * `:hosts` - A list of hostnames to respond to. Normally this would be set to
     `:hostname` and `mdns_lite` will advertise the actual hostname with `.local`
     appended.
   * `:ttl` - The default mDNS record time-to-live. The default of 120
@@ -99,7 +99,11 @@ defmodule MdnsLite.Options do
   @doc false
   @spec from_application_env() :: t()
   def from_application_env() do
-    hosts = Application.get_env(:mdns_lite, :host, @default_host_name_list)
+    # This used to be called :host, but now it's :hosts
+    hosts =
+      Application.get_env(:mdns_lite, :hosts) || Application.get_env(:mdns_lite, :host) ||
+        @default_host_name_list
+
     ttl = Application.get_env(:mdns_lite, :ttl, @default_ttl)
     config_services = Application.get_env(:mdns_lite, :services, []) |> filter_invalid_services()
     dns_bridge_enabled = Application.get_env(:mdns_lite, :dns_bridge_enabled, false)

--- a/lib/mdns_lite/options.ex
+++ b/lib/mdns_lite/options.ex
@@ -227,12 +227,10 @@ defmodule MdnsLite.Options do
   end
 
   @doc false
-  @spec set_host(t(), String.t() | :hostname) :: t()
-  def set_host(%__MODULE__{} = options, host) do
-    resolved_host = resolve_mdns_name(host)
-    dot_local_name = "#{resolved_host}.local"
-
-    %{options | dot_local_names: [dot_local_name], hosts: [resolved_host]}
+  @spec set_hosts(t(), [String.t() | :hostname]) :: t()
+  def set_hosts(%__MODULE__{} = options, hosts) do
+    %{options | dot_local_names: [], hosts: []}
+    |> add_hosts(hosts)
   end
 
   @doc false

--- a/lib/mdns_lite/responder.ex
+++ b/lib/mdns_lite/responder.ex
@@ -154,12 +154,14 @@ defmodule MdnsLite.Responder do
     data = :inet_dns.encode(message)
     dest = %{family: :inet, port: @mdns_port, addr: @mdns_ipv4}
 
-    case :socket.sendto(state.udp, data, dest) do
-      {:error, reason} ->
-        Logger.warn("mdns_lite multicast send failed: #{inspect(reason)}")
+    if state.udp do
+      case :socket.sendto(state.udp, data, dest) do
+        {:error, reason} ->
+          Logger.warn("mdns_lite multicast send failed: #{inspect(reason)}")
 
-      :ok ->
-        :ok
+        :ok ->
+          :ok
+      end
     end
 
     {:noreply, state}

--- a/test/mdns_lite/info_test.exs
+++ b/test/mdns_lite/info_test.exs
@@ -1,0 +1,37 @@
+defmodule MdnsLite.InfoTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+
+  alias MdnsLite.Info
+
+  test "tables match config" do
+    out = capture_io(&Info.dump_records/0)
+
+    {:ok, name} = :inet.gethostname()
+
+    # The lines aren't in guaranteed to be in this order, so check one by one
+    assert out =~ "<interface_ipv4>.in-addr.arpa: type PTR, class IN, ttl 120, #{name}.local"
+    assert out =~ "<interface_ipv6>.ip6.arpa: type PTR, class IN, ttl 120, #{name}.local"
+
+    assert out =~
+             "#{name}._http._tcp.local: type SRV, class IN, ttl 120, priority 0, weight 0, port 80, #{name}.local."
+
+    assert out =~ "#{name}._http._tcp.local: type TXT, class IN, ttl 120, key=value"
+
+    assert out =~
+             "#{name}._ssh._tcp.local: type SRV, class IN, ttl 120, priority 0, weight 0, port 22, #{name}.local."
+
+    assert out =~ "#{name}._ssh._tcp.local: type TXT, class IN, ttl 120"
+    assert out =~ "#{name}.local: type A, class IN, ttl 120, addr <interface_ipv4>"
+    assert out =~ "#{name}.local: type AAAA, class IN, ttl 120, addr <interface_ipv6>"
+    assert out =~ "_http._tcp.local: type PTR, class IN, ttl 120, #{name}._http._tcp.local"
+    assert out =~ "_services._dns-sd._udp.local: type PTR, class IN, ttl 120, _http._tcp.local"
+    assert out =~ "_services._dns-sd._udp.local: type PTR, class IN, ttl 120, _ssh._tcp.local"
+    assert out =~ "_ssh._tcp.local: type PTR, class IN, ttl 120, #{name}._ssh._tcp.local"
+    assert out =~ "nerves.local: type A, class IN, ttl 120, addr <interface_ipv4>"
+    assert out =~ "nerves.local: type AAAA, class IN, ttl 120, addr <interface_ipv6>"
+
+    line_count = out |> String.split("\n") |> length()
+    assert line_count == 16
+  end
+end

--- a/test/mdns_lite/options_test.exs
+++ b/test/mdns_lite/options_test.exs
@@ -47,7 +47,7 @@ defmodule MdnsLite.OptionsTest do
 
     options =
       Options.defaults()
-      |> Options.set_host(host)
+      |> Options.set_hosts([host])
 
     assert options.hosts == [host]
   end
@@ -58,7 +58,7 @@ defmodule MdnsLite.OptionsTest do
 
     options =
       Options.defaults()
-      |> Options.set_host(host)
+      |> Options.set_hosts([host])
       |> Options.add_host(host_alias)
 
     assert options.hosts == [host, host_alias]
@@ -67,7 +67,7 @@ defmodule MdnsLite.OptionsTest do
   test "fails with invalid host" do
     options = Options.defaults()
 
-    assert_raise RuntimeError, fn -> Options.set_host(options, :wat) end
+    assert_raise RuntimeError, fn -> Options.set_hosts(options, [:wat]) end
   end
 
   import ExUnit.CaptureLog

--- a/test/mdns_lite_test.exs
+++ b/test/mdns_lite_test.exs
@@ -1,0 +1,16 @@
+defmodule MdnsLiteTest do
+  use ExUnit.Case, async: false
+
+  describe "gethostbyname/1" do
+    test "query from our configuration" do
+      assert {:ok, {127, 0, 0, 1}} = MdnsLite.gethostbyname("nerves.local")
+
+      {:ok, hostname} = :inet.gethostname()
+      assert {:ok, {127, 0, 0, 1}} = MdnsLite.gethostbyname(to_string(hostname) <> ".local")
+    end
+
+    test "missing host" do
+      assert {:error, :nxdomain} = MdnsLite.gethostbyname("definitely-not-on-network.local", 0)
+    end
+  end
+end

--- a/test/mdns_lite_test.exs
+++ b/test/mdns_lite_test.exs
@@ -1,6 +1,17 @@
 defmodule MdnsLiteTest do
   use ExUnit.Case, async: false
 
+  describe "set_hosts/1" do
+    test "set hosts to something else" do
+      :ok = MdnsLite.set_hosts(["pineapple"])
+      assert {:ok, {127, 0, 0, 1}} = MdnsLite.gethostbyname("pineapple.local", 0)
+      assert {:error, :nxdomain} = MdnsLite.gethostbyname("nerves.local", 0)
+
+      # Restore the default
+      :ok = MdnsLite.set_hosts([:hostname, "nerves"])
+    end
+  end
+
   describe "gethostbyname/1" do
     test "query from our configuration" do
       assert {:ok, {127, 0, 0, 1}} = MdnsLite.gethostbyname("nerves.local")


### PR DESCRIPTION
This fixes a few things that I saw that would be good to fix before a release is
made. The `set_host` to `set_hosts` name change and the `host` to `hosts` config
key change are both API affecting. The latter one will accept the singular
version. In theory, `set_host` could be implemented to prevent breaking the API,
but there are so many changes in this release, that if you're actually using the
runtime configuration functions, you should review everything anyway.

- Fix word wrap issue in docs
- Support specifying timeouts on lookups
- Add a test for dumping records
- Add gethostbyname test
- Rename MdnsLite.set_host -> set_hosts
- Change the host config key to hosts
