### PR TITLE
Remove log message for DNS lookup failures

### DIFF
--- a/lib/mdns_lite/dns_bridge.ex
+++ b/lib/mdns_lite/dns_bridge.ex
@@ -137,9 +137,7 @@ defmodule MdnsLite.DNSBridge do
 
         dns_rec(result, header: dns_header(header, id: id))
 
-      {:error, reason} ->
-        Logger.error("Recursive lookup of #{domain} failed because #{inspect(reason)}")
-
+      {:error, _reason} ->
         lookup_failure(id, qdlist)
     end
   end


### PR DESCRIPTION
This turned out to be very verbose in the logs.
