### PR TITLE
Fix crash when interface goes away

### DIFF
--- a/lib/mdns_lite/vintage_net_monitor.ex
+++ b/lib/mdns_lite/vintage_net_monitor.ex
@@ -47,6 +47,11 @@ defmodule MdnsLite.VintageNetMonitor do
     set_vn_address(state, ifname, addresses)
   end
 
+  defp set_vn_address(state, ifname, nil) do
+    # nil gets passed when the network interface goes away.
+    set_vn_address(state, ifname, [])
+  end
+
   defp set_vn_address(state, ifname, addresses) do
     ip_list = Enum.map(addresses, fn %{address: ip} -> ip end)
     CoreMonitor.set_ip_list(state, ifname, ip_list)


### PR DESCRIPTION
This fixes:

```elixir
18:43:12.023 [error] GenServer MdnsLite.VintageNetMonitor terminating
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): CircularBuffer, HashSet, Range, Map, Function, List, Stream, Date.Range, HashDict, GenEvent.Stream, MapSet, File.Stream, IO.Stream
    (elixir 1.12.3) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.12.3) lib/enum.ex:141: Enumerable.reduce/3
    (elixir 1.12.3) lib/enum.ex:3958: Enum.map/2
    (mdns_lite 0.8.0) lib/mdns_lite/vintage_net_monitor.ex:51: MdnsLite.VintageNetMonitor.set_vn_address/3
    (mdns_lite 0.8.0) lib/mdns_lite/vintage_net_monitor.ex:40: MdnsLite.VintageNetMonitor.handle_info/2
    (stdlib 3.15.2) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.15.2) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.15.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {VintageNet, ["interface", "wwan0", "addresses"], [], nil, %{}}
State: %{excluded_ifnames: ["lo0", "lo", "ppp0", "wwan0"], filter: #Function<3.108465825/1 in MdnsLite.CoreMonitor."-fun.filter_by_ipv4/1-">, ip_list: %{"wlan0" => [{10, 1, 10, 149}]}, todo: []}
```
