### PR TITLE
Implement host & per-service instance_name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ A typical configuration in the `config.exs` file looks like:
 config :mdns_lite,
   # Advertise `hostname.local` on the LAN
   hosts: [:hostname],
+  # If instance_name is not defined it defaults to the first hostname
+  instance_name: "Awesome Device",
   services: [
     # Advertise an HTTP server running on port 80
     %{
@@ -63,19 +65,27 @@ usually the easiest way. The `protocol` and `transport` get combined to form the
 service type that's actually advertised on the network. For example, a "tcp"
 transport and "ssh" protocol will end up as `"_ssh._tcp"` in the advertisement.
 If you need something custom, specify `:type` directly. Optional fields include
-`:id`, `:weight`, `:priority`, and `:txt_payload`. An `:id` is needed to remove
-the service advertisement at runtime. A `:txt_payload` is a list of
-`"<key>=<value>"` string that will be advertised in a TXT DNS record
+`:id`, `:weight`, `:priority`, `:instance_name` and `:txt_payload`. An `:id` is 
+needed to remove the service advertisement at runtime. If not specified, 
+`:instance_name` is inherited from the top-level config.  A `:txt_payload` is a
+list of `"<key>=<value>"` string that will be advertised in a TXT DNS record
 corresponding to the service.
 
 See [`MdnsLite.Options`](https://hexdocs.pm/mdns_lite/MdnsLite.Options.html) for
 information about all application environment options.
 
-It's possible to change the advertised hostnames and services at runtime. For
-example, to change the list of advertised hostnames, run:
+It's possible to change the advertised hostnames, instance names and services at
+runtime. For example, to change the list of advertised hostnames, run:
 
 ```elixir
 iex> MdnsLite.set_host([:hostname, "nerves"])
+:ok
+```
+
+To change the advertised instance name:
+
+```elixir
+iex> MdnsLite.set_instance_name("My Other Awesome Device")
 :ok
 ```
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,6 +13,15 @@ config :mdns_lite,
   hosts: [:hostname, "nerves"],
   ttl: 120,
 
+  # instance_name is a user friendly name that will be used as the name for this
+  # device's advertised service(s). Per RFC6763 Appendix C, this should describe
+  # the user-facing purpose or description of the device, and should not be 
+  # considered a unique identifier. For example, 'Nerves Device' and 'MatCo 
+  # Laser Printer Model CRM-114' are good choices here.  If instance_name is not 
+  # defined it defaults to the first entry in the `hosts` list above
+  #
+  #instance_name: "mDNS Lite Device",
+
   # A list of this host's services. NB: There are two other mDNS values: weight
   # and priority that both default to zero unless included in the service below.
   # The txt_payload value is optional and can be used to define the data in TXT

--- a/lib/mdns_lite.ex
+++ b/lib/mdns_lite.ex
@@ -27,6 +27,11 @@ defmodule MdnsLite do
   @type service_id() :: atom() | binary()
 
   @typedoc """
+  A user-visible name for a service advertisement
+  """
+  @type instance_name() :: String.t() | :unspecified
+
+  @typedoc """
   mDNS service description
 
   Keys include:
@@ -51,6 +56,7 @@ defmodule MdnsLite do
   """
   @type service() :: %{
           :id => service_id(),
+          :instance_name => instance_name(),
           :port => 1..65535,
           optional(:txt_payload) => [String.t()],
           optional(:priority) => 0..255,
@@ -85,6 +91,16 @@ defmodule MdnsLite do
   @spec set_hosts([:hostname | String.t()]) :: :ok
   def set_hosts(hosts) do
     TableServer.update_options(&Options.set_hosts(&1, hosts))
+  end
+
+  @doc """
+  Updates the advertised instance name for service records
+
+  To specify the hostname returned by `:inet.gethostname/0`, use `:hostname`.
+  """
+  @spec set_instance_name(:hostname | String.t()) :: :ok
+  def set_instance_name(instance_name) do
+    TableServer.update_options(&Options.set_instance_name(&1, instance_name))
   end
 
   @doc """

--- a/lib/mdns_lite/table/builder.ex
+++ b/lib/mdns_lite/table/builder.ex
@@ -56,9 +56,21 @@ defmodule MdnsLite.Table.Builder do
   end
 
   defp service_resources(service, domain, config) do
-    # TODO: Add a service for each name?
-    name = hd(config.hosts)
-    service_instance_name = to_charlist("#{name}.#{service.type}.local")
+    service_instance_name =
+      case service.instance_name do
+        :unspecified ->
+          case config.instance_name do
+            :unspecified ->
+              name = hd(config.hosts)
+              to_charlist("#{name}.#{service.type}.local")
+
+            host_instance_name ->
+              to_charlist("#{host_instance_name}.#{service.type}.local")
+          end
+
+        service_instance_name ->
+          to_charlist("#{service_instance_name}.#{service.type}.local")
+      end
 
     first_dot_local_name = hd(config.dot_local_names)
     target = first_dot_local_name <> "."

--- a/test/mdns_lite/options_test.exs
+++ b/test/mdns_lite/options_test.exs
@@ -12,7 +12,8 @@ defmodule MdnsLite.OptionsTest do
              dot_local_names: ["#{hostname}.local"],
              hosts: ["#{hostname}"],
              services: MapSet.new(),
-             ttl: 120
+             ttl: 120,
+             instance_name: :unspecified
            }
   end
 
@@ -45,6 +46,7 @@ defmodule MdnsLite.OptionsTest do
     options =
       Options.add_service(options, %{
         id: :ssh_service,
+        instance_name: "banana",
         protocol: "ssh",
         transport: "tcp",
         port: 22
@@ -53,6 +55,7 @@ defmodule MdnsLite.OptionsTest do
     assert Options.get_services(options) == [
              %{
                id: :ssh_service,
+               instance_name: "banana",
                port: 22,
                priority: 0,
                txt_payload: [],
@@ -73,6 +76,16 @@ defmodule MdnsLite.OptionsTest do
       |> Options.set_hosts([host])
 
     assert options.hosts == [host]
+  end
+
+  test "can set instance name" do
+    instance_name = "My Device"
+
+    options =
+      Options.new()
+      |> Options.set_instance_name(instance_name)
+
+    assert options.instance_name == instance_name
   end
 
   test "can add hosts" do

--- a/test/mdns_lite/table_test.exs
+++ b/test/mdns_lite/table_test.exs
@@ -6,38 +6,35 @@ defmodule MdnsLite.TableTest do
 
   doctest MdnsLite.Table
 
-  defp test_table() do
-    config =
-      %Options{}
-      |> Options.add_hosts(["nerves-21a5", "nerves"])
-      |> Options.add_services([
-        %{
-          id: :http_service,
-          txt_payload: ["key=value"],
-          port: 80,
-          priority: 0,
-          protocol: "http",
-          transport: "tcp",
-          type: "_http._tcp",
-          weight: 0
-        },
-        %{
-          id: :ssh_service,
-          txt_payload: [""],
-          port: 22,
-          priority: 0,
-          protocol: "ssh",
-          transport: "tcp",
-          type: "_ssh._tcp",
-          weight: 0
-        }
-      ])
-
-    Table.Builder.from_options(config)
+  defp test_config() do
+    %Options{}
+    |> Options.add_hosts(["nerves-21a5", "nerves"])
+    |> Options.add_services([
+      %{
+        id: :http_service,
+        txt_payload: ["key=value"],
+        port: 80,
+        priority: 0,
+        protocol: "http",
+        transport: "tcp",
+        type: "_http._tcp",
+        weight: 0
+      },
+      %{
+        id: :ssh_service,
+        txt_payload: [""],
+        port: 22,
+        priority: 0,
+        protocol: "ssh",
+        transport: "tcp",
+        type: "_ssh._tcp",
+        weight: 0
+      }
+    ])
   end
 
-  def do_query(query) do
-    table = test_table()
+  def do_query(query, config \\ test_config()) do
+    table = Table.Builder.from_options(config)
     if_info = %MdnsLite.IfInfo{ipv4_address: {192, 168, 9, 57}}
     answer_rr = Table.query(table, query, if_info)
     additional_rr = Table.additional_records(table, answer_rr, if_info)
@@ -162,6 +159,120 @@ defmodule MdnsLite.TableTest do
     assert do_query(query) == result
   end
 
+  test "responds to a PTR request with a specific domain using host-level instance name" do
+    test_domain = '_http._tcp.local'
+    query = dns_query(domain: test_domain, type: :ptr, class: :in)
+
+    result = %{
+      answer: [
+        dns_rr(
+          domain: test_domain,
+          type: :ptr,
+          class: :in,
+          ttl: 120,
+          data: 'myidentifier._http._tcp.local'
+        )
+      ],
+      additional: [
+        dns_rr(
+          domain: 'myidentifier._http._tcp.local',
+          type: :srv,
+          class: :in,
+          ttl: 120,
+          data: {0, 0, 80, 'nerves-21a5.local.'}
+        ),
+        dns_rr(
+          domain: 'myidentifier._http._tcp.local',
+          type: :txt,
+          class: :in,
+          ttl: 120,
+          data: ["key=value"]
+        ),
+        dns_rr(
+          domain: 'nerves-21a5.local',
+          type: :a,
+          class: :in,
+          ttl: 120,
+          data: {192, 168, 9, 57}
+        )
+      ]
+    }
+
+    config =
+      %Options{}
+      |> Options.add_hosts(["nerves-21a5", "nerves"])
+      |> Options.set_instance_name("myidentifier")
+      |> Options.add_service(%{
+        id: :http_service,
+        txt_payload: ["key=value"],
+        port: 80,
+        priority: 0,
+        protocol: "http",
+        transport: "tcp",
+        type: "_http._tcp",
+        weight: 0
+      })
+
+    assert do_query(query, config) == result
+  end
+
+  test "responds to a PTR request with a specific domain using service-level instance name" do
+    test_domain = '_http._tcp.local'
+    query = dns_query(domain: test_domain, type: :ptr, class: :in)
+
+    result = %{
+      answer: [
+        dns_rr(
+          domain: test_domain,
+          type: :ptr,
+          class: :in,
+          ttl: 120,
+          data: 'myidentifier._http._tcp.local'
+        )
+      ],
+      additional: [
+        dns_rr(
+          domain: 'myidentifier._http._tcp.local',
+          type: :srv,
+          class: :in,
+          ttl: 120,
+          data: {0, 0, 80, 'nerves-21a5.local.'}
+        ),
+        dns_rr(
+          domain: 'myidentifier._http._tcp.local',
+          type: :txt,
+          class: :in,
+          ttl: 120,
+          data: ["key=value"]
+        ),
+        dns_rr(
+          domain: 'nerves-21a5.local',
+          type: :a,
+          class: :in,
+          ttl: 120,
+          data: {192, 168, 9, 57}
+        )
+      ]
+    }
+
+    config =
+      %Options{}
+      |> Options.add_hosts(["nerves-21a5", "nerves"])
+      |> Options.add_service(%{
+        id: :http_service,
+        instance_name: "myidentifier",
+        txt_payload: ["key=value"],
+        port: 80,
+        priority: 0,
+        protocol: "http",
+        transport: "tcp",
+        type: "_http._tcp",
+        weight: 0
+      })
+
+    assert do_query(query, config) == result
+  end
+
   test "responds to a PTR request with domain \'_services._dns-sd._udp.local\'" do
     test_domain = '_services._dns-sd._udp.local'
     query = dns_query(domain: test_domain, type: :ptr, class: :in)
@@ -209,6 +320,80 @@ defmodule MdnsLite.TableTest do
     }
 
     assert do_query(query) == result
+  end
+
+  test "responds to an SRV request for a known service with host-level instance name" do
+    known_service = "myidentifier._http._tcp.local"
+    query = dns_query(domain: to_charlist(known_service), type: :srv, class: :in)
+
+    result = %{
+      answer: [
+        dns_rr(
+          domain: 'myidentifier._http._tcp.local',
+          type: :srv,
+          class: :in,
+          ttl: 120,
+          data: {0, 0, 80, 'nerves-21a5.local.'}
+        )
+      ],
+      additional: [
+        {:dns_rr, 'nerves-21a5.local', :a, :in, 0, 120, {192, 168, 9, 57}, :undefined, [], false}
+      ]
+    }
+
+    config =
+      %Options{}
+      |> Options.add_hosts(["nerves-21a5", "nerves"])
+      |> Options.set_instance_name("myidentifier")
+      |> Options.add_service(%{
+        id: :http_service,
+        txt_payload: ["key=value"],
+        port: 80,
+        priority: 0,
+        protocol: "http",
+        transport: "tcp",
+        type: "_http._tcp",
+        weight: 0
+      })
+
+    assert do_query(query, config) == result
+  end
+
+  test "responds to an SRV request for a known service with service-level instance name" do
+    known_service = "myidentifier._http._tcp.local"
+    query = dns_query(domain: to_charlist(known_service), type: :srv, class: :in)
+
+    result = %{
+      answer: [
+        dns_rr(
+          domain: 'myidentifier._http._tcp.local',
+          type: :srv,
+          class: :in,
+          ttl: 120,
+          data: {0, 0, 80, 'nerves-21a5.local.'}
+        )
+      ],
+      additional: [
+        {:dns_rr, 'nerves-21a5.local', :a, :in, 0, 120, {192, 168, 9, 57}, :undefined, [], false}
+      ]
+    }
+
+    config =
+      %Options{}
+      |> Options.add_hosts(["nerves-21a5", "nerves"])
+      |> Options.add_service(%{
+        id: :http_service,
+        instance_name: "myidentifier",
+        txt_payload: ["key=value"],
+        port: 80,
+        priority: 0,
+        protocol: "http",
+        transport: "tcp",
+        type: "_http._tcp",
+        weight: 0
+      })
+
+    assert do_query(query, config) == result
   end
 
   test "ignore SRV request without the instance name" do


### PR DESCRIPTION
Redo of #10 on top of the new mDNS Lite implementation. Documentation in README & relevant ex_docs updated, tests improved to cover new cases in options & table builder.