### PR TITLE
Make vintage_net an optional dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ install_system_deps: &install_system_deps
 jobs:
   build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.12.2-erlang-24.0.5-alpine-3.14.0
+      - image: hexpm/elixir:1.12.2-erlang-24.1.4-alpine-3.14.2
     <<: *defaults
     steps:
       - checkout

--- a/lib/mdns_lite/options.ex
+++ b/lib/mdns_lite/options.ex
@@ -74,7 +74,6 @@ defmodule MdnsLite.Options do
   @default_ttl 120
   @default_dns_ip {127, 0, 0, 53}
   @default_dns_port 53
-  @default_monitor MdnsLite.VintageNetMonitor
   @default_excluded_ifnames ["lo0", "lo", "ppp0", "wwan0"]
   @default_ipv4_only true
 
@@ -87,7 +86,7 @@ defmodule MdnsLite.Options do
             dns_bridge_ip: @default_dns_ip,
             dns_bridge_port: @default_dns_port,
             dns_bridge_recursive: true,
-            if_monitor: @default_monitor,
+            if_monitor: nil,
             excluded_ifnames: @default_excluded_ifnames,
             ipv4_only: @default_ipv4_only
 
@@ -120,7 +119,7 @@ defmodule MdnsLite.Options do
     dns_bridge_ip = Map.get(opts, :dns_bridge_ip, @default_dns_ip)
     dns_bridge_port = Map.get(opts, :dns_bridge_port, @default_dns_port)
     dns_bridge_recursive = Map.get(opts, :dns_bridge_recursive, true)
-    if_monitor = Map.get(opts, :if_monitor, @default_monitor)
+    if_monitor = Map.get(opts, :if_monitor, default_if_monitor())
     ipv4_only = Map.get(opts, :ipv4_only, @default_ipv4_only)
     excluded_ifnames = Map.get(opts, :excluded_ifnames, @default_excluded_ifnames)
 
@@ -137,6 +136,19 @@ defmodule MdnsLite.Options do
     }
     |> add_hosts(hosts)
     |> add_services(config_services)
+  end
+
+  defp default_if_monitor() do
+    if has_vintage_net?() do
+      MdnsLite.VintageNetMonitor
+    else
+      MdnsLite.InetMonitor
+    end
+  end
+
+  defp has_vintage_net?() do
+    Application.loaded_applications()
+    |> Enum.find_value(fn {app, _, _} -> app == :vintage_net end)
   end
 
   # This used to be called :host, but now it's :hosts. It's a list, but be

--- a/lib/mdns_lite/vintage_net_monitor.ex
+++ b/lib/mdns_lite/vintage_net_monitor.ex
@@ -18,6 +18,12 @@ defmodule MdnsLite.VintageNetMonitor do
 
   @impl GenServer
   def init(opts) do
+    # VintageNet is an optional dependency. Optional dependencies aren't
+    # guaranteed to be started in order. See
+    # https://github.com/elixir-lang/elixir/issues/10433. To work around this,
+    # try to start it.
+    _ = Application.ensure_all_started(:vintage_net)
+
     VintageNet.subscribe(@addresses_topic)
 
     {:ok, CoreMonitor.init(opts), {:continue, :initialization}}

--- a/mix.exs
+++ b/mix.exs
@@ -47,13 +47,14 @@ defmodule MdnsLite.MixProject do
       {:dialyxir, "~> 1.1", only: :dev, runtime: false},
       {:credo, "~> 1.2", only: :test, runtime: false},
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},
-      {:vintage_net, "~> 0.7"}
+      {:vintage_net, "~> 0.7", optional: true}
     ]
   end
 
   defp dialyzer() do
     [
-      flags: [:unmatched_returns, :error_handling, :race_conditions, :underspecs]
+      flags: [:unmatched_returns, :error_handling, :race_conditions, :underspecs],
+      plt_add_apps: [:vintage_net]
     ]
   end
 

--- a/test/mdns_lite/options_test.exs
+++ b/test/mdns_lite/options_test.exs
@@ -8,12 +8,18 @@ defmodule MdnsLite.OptionsTest do
   test "default options" do
     {:ok, hostname} = :inet.gethostname()
 
+    expected_if_monitor =
+      if Version.match?(System.version(), "~> 1.11"),
+        do: MdnsLite.VintageNetMonitor,
+        else: MdnsLite.InetMonitor
+
     assert Options.new() == %Options{
              dot_local_names: ["#{hostname}.local"],
              hosts: ["#{hostname}"],
              services: MapSet.new(),
              ttl: 120,
-             instance_name: :unspecified
+             instance_name: :unspecified,
+             if_monitor: expected_if_monitor
            }
   end
 


### PR DESCRIPTION
This makes it possible to use mdns_lite without configuration
vintage_net to not try to take over the system.
