### PR TITLE
Use new OTP DNS support for mDNS messages

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,0 +1,4 @@
+# Run `mix dialyzer --format short` for strings
+[
+  {"lib/mdns_lite/dns.ex:30:contract_supertype Type specification for decode is a supertype of the success typing."}
+]

--- a/lib/mdns_lite/cache.ex
+++ b/lib/mdns_lite/cache.ex
@@ -1,7 +1,6 @@
 defmodule MdnsLite.Cache do
+  alias MdnsLite.DNS
   import MdnsLite.DNS
-
-  alias MdnsLite.{DNS, Utilities}
 
   @moduledoc """
   Cache for records received over mDNS
@@ -120,8 +119,8 @@ defmodule MdnsLite.Cache do
     insert_or_update(rest, new_rr, [rr | result])
   end
 
-  defp normalize_record(dns_rr(class: class, ttl: ttl) = record) do
-    dns_rr(record, ttl: normalize_ttl(ttl), class: Utilities.normalize_class(class))
+  defp normalize_record(dns_rr(ttl: ttl) = record) do
+    dns_rr(record, ttl: normalize_ttl(ttl))
   end
 
   defp normalize_ttl(ttl) when ttl > @max_ttl, do: @max_ttl

--- a/lib/mdns_lite/client.ex
+++ b/lib/mdns_lite/client.ex
@@ -34,13 +34,10 @@ defmodule MdnsLite.Client do
       # arlist A list of resource entries. Can be empty.
       arlist: []
     )
-    |> :inet_dns.encode()
+    |> DNS.encode()
   end
 
-  defp request_unicast(dns_query(class: class) = query, value) do
-    dns_query(query, class: set_unicast_bit(class, value))
+  defp request_unicast(query, value) do
+    dns_query(query, unicast_response: !!value)
   end
-
-  defp set_unicast_bit(:in, true), do: 0x8001
-  defp set_unicast_bit(class, _not_true), do: class
 end

--- a/lib/mdns_lite/dns.ex
+++ b/lib/mdns_lite/dns.ex
@@ -4,17 +4,37 @@ defmodule MdnsLite.DNS do
   """
   import Record, only: [defrecord: 2]
 
-  @inet_dns "kernel/src/inet_dns.hrl"
+  @inet_dns "src/mdns_lite_inet_dns.hrl"
 
-  defrecord :dns_rec, Record.extract(:dns_rec, from_lib: @inet_dns)
-  defrecord :dns_header, Record.extract(:dns_header, from_lib: @inet_dns)
-  defrecord :dns_query, Record.extract(:dns_query, from_lib: @inet_dns)
-  defrecord :dns_rr, Record.extract(:dns_rr, from_lib: @inet_dns)
+  defrecord :dns_rec, Record.extract(:dns_rec, from: @inet_dns)
+  defrecord :dns_header, Record.extract(:dns_header, from: @inet_dns)
+  defrecord :dns_query, Record.extract(:dns_query, from: @inet_dns)
+  defrecord :dns_rr, Record.extract(:dns_rr, from: @inet_dns)
 
   @type dns_query :: record(:dns_query, [])
   @type dns_rr :: record(:dns_rr, [])
   @type dns_rec :: record(:dns_rec, [])
 
+  @doc """
+  Encode a DNS record
+  """
+  @spec encode(dns_rec()) :: binary()
+  def encode(rec) do
+    # Use the new version of :inet_dns that supports RFC 6762
+    :mdns_lite_inet_dns.encode(rec)
+  end
+
+  @doc """
+  Decode a packet that contains a DNS message
+  """
+  @spec decode(binary()) :: {:ok, dns_rec()} | {:error, any()}
+  def decode(packet) do
+    :mdns_lite_inet_dns.decode(packet)
+  end
+
+  @doc """
+  Format a DNS record as a nice string for the user
+  """
   @spec pretty(dns_rr()) :: String.t()
   def pretty(dns_rr(domain: domain, type: :a, class: :in, ttl: ttl, data: data)) do
     "#{domain}: type A, class IN, ttl #{ttl}, addr #{ntoa(data)}"

--- a/lib/mdns_lite/dns_bridge.ex
+++ b/lib/mdns_lite/dns_bridge.ex
@@ -22,7 +22,7 @@ defmodule MdnsLite.DNSBridge do
   use GenServer
   require Logger
 
-  alias MdnsLite.Options
+  alias MdnsLite.{DNS, Options}
   import MdnsLite.DNS
 
   @doc false
@@ -53,7 +53,7 @@ defmodule MdnsLite.DNSBridge do
   @impl GenServer
   def handle_info({:udp, _socket, src_ip, src_port, packet}, state) do
     # Decode the UDP packet
-    with {:ok, dns_record} <- :inet_dns.decode(packet),
+    with {:ok, dns_record} <- DNS.decode(packet),
          dns_rec(header: header, qdlist: qdlist) = dns_record,
          # qr is the query/response flag; false (0) = query, true (1) = response
          dns_header(qr: false) <- header do
@@ -89,7 +89,7 @@ defmodule MdnsLite.DNSBridge do
         lookup_failure(id, qdlist)
       end
 
-    packet = :inet_dns.encode(result)
+    packet = DNS.encode(result)
     _ = :gen_udp.send(state.udp, dest_address, dest_port, packet)
 
     :ok
@@ -115,7 +115,7 @@ defmodule MdnsLite.DNSBridge do
         arlist: result.additional
       )
 
-    dns_record = :inet_dns.encode(packet)
+    dns_record = DNS.encode(packet)
     :gen_udp.send(state.udp, dest_address, dest_port, dns_record)
   end
 

--- a/lib/mdns_lite/table.ex
+++ b/lib/mdns_lite/table.ex
@@ -1,6 +1,6 @@
 defmodule MdnsLite.Table do
   import MdnsLite.DNS
-  alias MdnsLite.{DNS, IfInfo, Utilities}
+  alias MdnsLite.{DNS, IfInfo}
 
   @type t() :: [DNS.dns_rr()]
 
@@ -101,15 +101,15 @@ defmodule MdnsLite.Table do
     end)
   end
 
-  defp normalize_query(dns_query(class: class, type: :ptr, domain: domain) = q, if_info) do
+  defp normalize_query(dns_query(class: :in, type: :ptr, domain: domain) = q, if_info) do
     case test_known_in_addr_arpa(domain, if_info) do
-      {:ok, value} -> dns_query(class: :in, type: :ptr, domain: value)
-      _ -> dns_query(q, class: Utilities.normalize_class(class))
+      {:ok, value} -> dns_query(q, domain: value)
+      _ -> q
     end
   end
 
-  defp normalize_query(dns_query(domain: domain, type: type, class: class), _if_info) do
-    dns_query(domain: domain, type: type, class: Utilities.normalize_class(class))
+  defp normalize_query(query, _if_info) do
+    query
   end
 
   # TODO: Fate sharing - send IPv6 records when sending IPv4 ones and vice versa

--- a/lib/mdns_lite/utilities.ex
+++ b/lib/mdns_lite/utilities.ex
@@ -28,14 +28,4 @@ defmodule MdnsLite.Utilities do
   @spec ip_family(:inet.ip_address()) :: :inet | :inet6
   def ip_family({_, _, _, _}), do: :inet
   def ip_family({_, _, _, _, _, _, _, _}), do: :inet6
-
-  @doc """
-  Strip the flag bit off the class value
-
-  This is required since OTP doesn't know about it and will return numbers rather than the
-  the `:in` class.
-  """
-  @spec normalize_class(:in | 0..65535) :: :in | 0..65535
-  def normalize_class(32769), do: :in
-  def normalize_class(other), do: other
 end

--- a/mix.exs
+++ b/mix.exs
@@ -54,6 +54,7 @@ defmodule MdnsLite.MixProject do
   defp dialyzer() do
     [
       flags: [:unmatched_returns, :error_handling, :race_conditions, :underspecs],
+      ignore_warnings: ".dialyzer_ignore.exs",
       plt_add_apps: [:vintage_net]
     ]
   end

--- a/src/mdns_lite_inet_dns.erl
+++ b/src/mdns_lite_inet_dns.erl
@@ -1,0 +1,856 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(mdns_lite_inet_dns).
+
+%% Dns record encode/decode
+%%
+%% RFC 1035: Domain Names - Implementation and Specification
+%% RFC 2181: Clarifications to the DNS Specification
+%% RFC 2671: Extension Mechanisms for DNS (EDNS0)
+%% RFC 2782: A DNS RR for specifying the location of services (DNS SRV)
+%% RFC 2915: The Naming Authority Pointer (NAPTR) DNS Resource Rec
+%% RFC 6488: DNS Certification Authority Authorization (CAA) Resource Record
+%% RFC 7553: The Uniform Resource Identifier (URI) DNS Resource Record
+%% RFC 6762: Multicast DNS
+
+-export([decode/1, encode/1]).
+
+-import(lists, [reverse/1]).
+
+-include("src/mdns_lite_inet_int.hrl").
+-include("src/mdns_lite_inet_dns.hrl").
+
+-export([record_type/1, rr/1, rr/2]).
+-export([make_rr/0, make_rr/1, make_rr/2, make_rr/3]).
+%% ADTs exports. The make_* functions are undocumented.
+-export([msg/1, msg/2,
+	 make_msg/0, make_msg/1, make_msg/2, make_msg/3]).
+-export([header/1, header/2,
+	 make_header/0, make_header/1, make_header/2, make_header/3]).
+-export([dns_query/1, dns_query/2,
+	 make_dns_query/0, make_dns_query/1,
+	 make_dns_query/2, make_dns_query/3]).
+-include("src/mdns_lite_inet_dns_record_adts.hrl").
+
+%% Function merge of #dns_rr{} and #dns_rr_opt{}
+%%
+
+record_type(#dns_rr{}) -> rr;
+record_type(#dns_rr_opt{}) -> rr;
+record_type(Rec) ->
+    record_adts(Rec).
+
+rr(#dns_rr{}=RR) -> dns_rr(RR);
+rr(#dns_rr_opt{}=RR) -> dns_rr_opt(RR).
+
+rr(#dns_rr{}=RR, L) -> dns_rr(RR, L);
+rr(#dns_rr_opt{}=RR, L) -> dns_rr_opt(RR, L).
+
+make_rr() -> make_dns_rr().
+
+make_rr(L) when is_list(L) ->
+    case rr_type(L, any) of
+	opt -> make_dns_rr_opt(L);
+	_ -> make_dns_rr(L)
+    end.
+
+make_rr(type, opt) -> make_dns_rr_opt();
+make_rr(F, V) when is_atom(F) -> make_dns_rr(F, V);
+make_rr(#dns_rr{}=RR, L) when is_list(L) ->
+    case rr_type(L, RR#dns_rr.type) of
+	opt ->
+	    Ts = common_fields__rr__rr_opt(),
+	    make_dns_rr_opt([Opt || {T,_}=Opt <- dns_rr(RR),
+				    lists_member(T, Ts)] ++ L);
+	_ -> make_dns_rr(RR, L)
+    end;
+make_rr(#dns_rr_opt{}=RR, L) when is_list(L) ->
+    case rr_type(L, RR#dns_rr_opt.type) of
+	opt ->
+	     make_dns_rr_opt(RR, L);
+	_ ->
+	    Ts = common_fields__rr__rr_opt(),
+	    make_dns_rr([Opt || {T,_}=Opt <- dns_rr_opt(RR),
+				lists_member(T, Ts)] ++ L)
+    end.
+
+make_rr(#dns_rr{}=RR, type, opt) -> make_rr(RR, [{type,opt}]);
+make_rr(#dns_rr{}=RR, F, V) -> make_dns_rr(RR, F, V);
+make_rr(#dns_rr_opt{}=RR, type, opt) -> RR;
+make_rr(#dns_rr_opt{}=RR, type, T) -> make_rr(RR, [{type,T}]);
+make_rr(#dns_rr_opt{}=RR, F, V) -> make_dns_rr_opt(RR, F, V).
+
+-compile({inline, [rr_type/2]}).
+rr_type([], T) -> T;
+rr_type([{type,T}|Opts], _) -> rr_type(Opts, T);
+rr_type([_|Opts], T) -> rr_type(Opts, T).
+
+common_fields__rr__rr_opt() ->
+    [T || T <- record_info(fields, dns_rr_opt),
+	  lists_member(T, record_info(fields, dns_rr))].
+
+-compile({inline, [lists_member/2]}).
+lists_member(_, []) -> false;
+lists_member(H, [H|_]) -> true;
+lists_member(H, [_|T]) -> lists_member(H, T).
+
+
+%% must match a clause in inet_res:query_nss_e?dns
+-define(DECODE_ERROR, formerr).
+
+%%
+%% Decode a dns buffer.
+%%
+
+%% Match macros that throw(?DECODE_ERROR) for no match
+-define(
+   MATCH_ELSE_DECODE_ERROR(Match, Pattern, Result),
+   case begin Match end of
+       (Pattern) ->
+           begin Result end;
+       _ ->
+           throw(?DECODE_ERROR)
+   end).
+-define(
+   MATCH_ELSE_DECODE_ERROR(Match, Pattern, Guard, Result),
+   case begin Match end of
+       (Pattern) when not not (Guard) ->
+           begin Result end;
+       _ ->
+           throw(?DECODE_ERROR)
+   end).
+
+decode(Buffer) when is_binary(Buffer) ->
+    try do_decode(Buffer) of
+	DnsRec ->
+	    {ok,DnsRec}
+    catch
+	Reason ->
+	    {error,Reason}
+    end.
+
+do_decode(<<Id:16,
+	   QR:1,Opcode:4,AA:1,TC:1,RD:1,
+	   RA:1,PR:1,_:2,Rcode:4,
+	   QdCount:16,AnCount:16,NsCount:16,ArCount:16,
+	   QdBuf/binary>>=Buffer) ->
+    {AnBuf,QdList,QdTC} = decode_query_section(QdBuf,QdCount,Buffer),
+    {NsBuf,AnList,AnTC} = decode_rr_section(AnBuf,AnCount,Buffer),
+    {ArBuf,NsList,NsTC} = decode_rr_section(NsBuf,NsCount,Buffer),
+    {Rest,ArList,ArTC} = decode_rr_section(ArBuf,ArCount,Buffer),
+    ?MATCH_ELSE_DECODE_ERROR(
+       Rest,
+       <<>>,
+       begin
+           HdrTC = decode_boolean(TC),
+           DnsHdr =
+               #dns_header{id=Id,
+                           qr=decode_boolean(QR),
+                           opcode=decode_opcode(Opcode),
+                           aa=decode_boolean(AA),
+                           tc=HdrTC,
+                           rd=decode_boolean(RD),
+                           ra=decode_boolean(RA),
+                           pr=decode_boolean(PR),
+                           rcode=Rcode},
+           ?MATCH_ELSE_DECODE_ERROR(
+              %% Header marked as truncated, or no section
+              %% marked as truncated.
+              %% The converse; a section marked as truncated,
+              %% but not the header - is a parse error.
+              %%
+              HdrTC or (not (QdTC or AnTC or NsTC or ArTC)),
+              true,
+              begin
+                  #dns_rec{header=DnsHdr,
+                           qdlist=QdList,
+                           anlist=AnList,
+                           nslist=NsList,
+                           arlist=ArList}
+              end)
+       end);
+do_decode(_) ->
+    %% DNS message does not even match header
+    throw(?DECODE_ERROR).
+
+decode_query_section(Bin, N, Buffer) ->
+    decode_query_section(Bin, N, Buffer, []).
+
+decode_query_section(<<>>=Rest, N, _Buffer, Qs) ->
+    {Rest,reverse(Qs),N =/= 0};
+decode_query_section(Rest, 0, _Buffer, Qs) ->
+    {Rest,reverse(Qs),false};
+decode_query_section(Bin, N, Buffer, Qs) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       decode_name(Bin, Buffer),
+       {<<T:16,C:16,Rest/binary>>,Name},
+       begin
+           {Class,UnicastResponse} = decode_class(C),
+           DnsQuery =
+               #dns_query{
+                  domain           = Name,
+                  type             = decode_type(T),
+                  class            = Class,
+                  unicast_response = UnicastResponse},
+           decode_query_section(Rest, N-1, Buffer, [DnsQuery|Qs])
+       end).
+
+decode_rr_section(Bin, N, Buffer) ->
+    decode_rr_section(Bin, N, Buffer, []).
+
+decode_rr_section(<<>>=Rest, N, _Buffer, RRs) ->
+    {Rest,reverse(RRs),N =/= 0};
+decode_rr_section(Rest, 0, _Buffer, RRs) ->
+    {Rest,reverse(RRs),false};
+decode_rr_section(Bin, N, Buffer, RRs) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       decode_name(Bin, Buffer),
+       {<<T:16/unsigned,C:16/unsigned,TTL:4/binary,
+	  Len:16,D:Len/binary,Rest/binary>>,
+        Name},
+       begin
+           Type = decode_type(T),
+           RR =
+               case Type of
+                   ?S_OPT ->
+                       <<ExtRcode,Version,Z:16>> = TTL,
+                       #dns_rr_opt{
+                          domain           = Name,
+                          type             = Type,
+                          udp_payload_size = C,
+                          ext_rcode        = ExtRcode,
+                          version          = Version,
+                          z                = Z,
+                          data             = D};
+                   _ ->
+                       {Class,CacheFlush} = decode_class(C),
+                       Data = decode_data(D, Class, Type, Buffer),
+                       <<TimeToLive:32/signed>> = TTL,
+                       #dns_rr{
+                          domain = Name,
+                          type   = Type,
+                          class  = Class,
+                          ttl    = max(0, TimeToLive),
+                          data   = Data,
+                          func   = CacheFlush}
+               end,
+           decode_rr_section(Rest, N-1, Buffer, [RR|RRs])
+       end).
+
+%%
+%% Encode a user query
+%%
+
+encode(Q) ->
+    QdCount = length(Q#dns_rec.qdlist),
+    AnCount = length(Q#dns_rec.anlist),
+    NsCount = length(Q#dns_rec.nslist),
+    ArCount = length(Q#dns_rec.arlist),
+    B0 = encode_header(Q#dns_rec.header, QdCount, AnCount, NsCount, ArCount),
+    C0 = gb_trees:empty(),
+    {B1,C1} = encode_query_section(B0, C0, Q#dns_rec.qdlist),
+    {B2,C2} = encode_res_section(B1, C1, Q#dns_rec.anlist),
+    {B3,C3} = encode_res_section(B2, C2, Q#dns_rec.nslist),
+    {B,_} = encode_res_section(B3, C3, Q#dns_rec.arlist),
+    B.
+
+
+%% RFC 1035: 4.1.1. Header section format
+%%
+encode_header(#dns_header{id=Id}=H, QdCount, AnCount, NsCount, ArCount) ->
+    QR = encode_boolean(H#dns_header.qr),
+    Opcode = encode_opcode(H#dns_header.opcode),
+    AA = encode_boolean(H#dns_header.aa),
+    TC = encode_boolean(H#dns_header.tc),
+    RD = encode_boolean(H#dns_header.rd),
+    RA = encode_boolean(H#dns_header.ra),
+    PR = encode_boolean(H#dns_header.pr),
+    Rcode = H#dns_header.rcode,
+    <<Id:16,
+     QR:1,Opcode:4,AA:1,TC:1,RD:1,
+     RA:1,PR:1,0:2,Rcode:4,
+     QdCount:16,AnCount:16,NsCount:16,ArCount:16>>.
+
+%% RFC 1035: 4.1.2. Question section format
+%%
+encode_query_section(Bin, Comp, []) -> {Bin,Comp};
+encode_query_section(Bin0, Comp0, [#dns_query{domain=DName}=Q | Qs]) ->
+    T = encode_type(Q#dns_query.type),
+    C = encode_class(Q#dns_query.class, Q#dns_query.unicast_response),
+    {Bin,Comp} = encode_name(Bin0, Comp0, byte_size(Bin0), DName),
+    encode_query_section(<<Bin/binary,T:16,C:16>>, Comp, Qs).
+
+%% RFC 1035: 4.1.3. Resource record format
+%% RFC 2671: 4.3, 4.4, 4.6 OPT RR format
+%%
+encode_res_section(Bin, Comp, []) -> {Bin,Comp};
+encode_res_section(
+  Bin, Comp,
+  [#dns_rr{
+      domain = DName,
+      type   = Type,
+      class  = Class,
+      func   = CacheFlush,
+      ttl    = TTL,
+      data   = Data} | Rs]) ->
+    encode_res_section_rr(
+      Bin, Comp, Rs, DName, Type, Class, CacheFlush,
+      <<TTL:32/signed>>, Data);
+encode_res_section(
+  Bin, Comp,
+  [#dns_rr_opt{
+      domain           = DName,
+      udp_payload_size = UdpPayloadSize,
+      ext_rcode        = ExtRCode,
+      version          = Version,
+      z                = Z,
+      data             = Data} | Rs]) ->
+    encode_res_section_rr(
+      Bin, Comp, Rs, DName, ?S_OPT, UdpPayloadSize, false,
+      <<ExtRCode,Version,Z:16>>, Data).
+
+encode_res_section_rr(
+  Bin0, Comp0, Rs, DName, Type, Class, CacheFlush, TTL, Data) ->
+    T = encode_type(Type),
+    C = encode_class(Class, CacheFlush),
+    {Bin,Comp1} = encode_name(Bin0, Comp0, byte_size(Bin0), DName),
+    Pos = byte_size(Bin)+2+2+byte_size(TTL)+2,
+    {DataBin,Comp} = encode_data(Comp1, Pos, Type, Class, Data),
+    DataSize = byte_size(DataBin),
+    encode_res_section(
+      <<Bin/binary,T:16,C:16,TTL/binary,DataSize:16,DataBin/binary>>,
+      Comp, Rs).
+
+%%
+%% Resource types
+%%
+decode_type(Type) ->
+    case Type of
+	?T_A -> ?S_A;
+	?T_NS -> ?S_NS;
+	?T_MD -> ?S_MD;
+	?T_MF -> ?S_MF;
+	?T_CNAME -> ?S_CNAME;
+	?T_SOA -> ?S_SOA;
+	?T_MB  -> ?S_MB;
+	?T_MG  -> ?S_MG;
+	?T_MR  -> ?S_MR;
+	?T_NULL -> ?S_NULL;
+	?T_WKS  -> ?S_WKS;
+	?T_PTR  -> ?S_PTR;
+	?T_HINFO -> ?S_HINFO;
+	?T_MINFO -> ?S_MINFO;
+	?T_MX -> ?S_MX;
+	?T_TXT -> ?S_TXT;
+	?T_AAAA -> ?S_AAAA;
+	?T_SRV -> ?S_SRV;
+	?T_NAPTR -> ?S_NAPTR;
+	?T_OPT -> ?S_OPT;
+	?T_SPF -> ?S_SPF;
+	%% non standard
+	?T_UINFO -> ?S_UINFO;
+	?T_UID -> ?S_UID;
+	?T_GID -> ?S_GID;
+	?T_UNSPEC -> ?S_UNSPEC;
+	%% Query type values which do not appear in resource records
+	?T_AXFR -> ?S_AXFR;
+	?T_MAILB -> ?S_MAILB;
+	?T_MAILA -> ?S_MAILA;
+	?T_ANY  -> ?S_ANY;
+	?T_URI  -> ?S_URI;
+	?T_CAA  -> ?S_CAA;
+	_ -> Type    %% raw unknown type
+    end.
+
+%%
+%% Resource types
+%%
+encode_type(Type) ->
+    case Type of
+	?S_A -> ?T_A;
+	?S_NS -> ?T_NS;
+	?S_MD -> ?T_MD;
+	?S_MF -> ?T_MF;
+	?S_CNAME -> ?T_CNAME;
+	?S_SOA -> ?T_SOA;
+	?S_MB -> ?T_MB;
+	?S_MG -> ?T_MG;
+	?S_MR -> ?T_MR;
+	?S_NULL -> ?T_NULL;
+	?S_WKS -> ?T_WKS;
+	?S_PTR -> ?T_PTR;
+	?S_HINFO -> ?T_HINFO;
+	?S_MINFO -> ?T_MINFO;
+	?S_MX -> ?T_MX;
+	?S_TXT -> ?T_TXT;
+	?S_AAAA -> ?T_AAAA;
+	?S_SRV -> ?T_SRV;
+	?S_NAPTR -> ?T_NAPTR;
+	?S_OPT -> ?T_OPT;
+	?S_SPF -> ?T_SPF;
+	%% non standard
+	?S_UINFO -> ?T_UINFO;
+	?S_UID -> ?T_UID;
+	?S_GID -> ?T_GID;
+	?S_UNSPEC -> ?T_UNSPEC;
+	%% Query type values which do not appear in resource records
+	?S_AXFR -> ?T_AXFR;
+	?S_MAILB -> ?T_MAILB;
+	?S_MAILA -> ?T_MAILA;
+	?S_ANY -> ?T_ANY;
+	?S_URI -> ?T_URI;
+	?S_CAA -> ?T_CAA;
+	Type when is_integer(Type) -> Type    %% raw unknown type
+    end.
+
+
+%%
+%% Resource classes
+%%
+
+decode_class(C0) ->
+    FlagBit = 16#8000,
+    C = C0 band (bnot FlagBit),
+    Class =
+        case C of
+            ?C_IN    -> in;
+            ?C_CHAOS -> chaos;
+            ?C_HS    -> hs;
+            ?C_ANY   -> any;
+            _ -> C    %% raw unknown class
+        end,
+    Flag = (C0 band FlagBit) =/= 0,
+    {Class,Flag}.
+
+
+encode_class(Class, Flag) ->
+    C = encode_class(Class),
+    case Flag of
+        true  -> FlagBit = 16#8000, C bor FlagBit;
+        false -> C
+    end.
+%%
+encode_class(Class) ->
+    case Class of
+	in    -> ?C_IN;
+	chaos -> ?C_CHAOS;
+	hs    -> ?C_HS;
+	any   -> ?C_ANY;
+	Class when is_integer(Class) -> Class    %% raw unknown class
+    end.
+
+decode_opcode(Opcode) ->
+    case Opcode of
+	?QUERY -> 'query';
+	?IQUERY -> iquery;
+	?STATUS -> status;
+	_ when is_integer(Opcode) -> Opcode %% non-standard opcode
+    end.
+
+encode_opcode(Opcode) ->
+    case Opcode of
+	'query' -> ?QUERY;
+	iquery -> ?IQUERY;
+	status -> ?STATUS;
+	_ when is_integer(Opcode) -> Opcode %% non-standard opcode
+    end.
+
+
+encode_boolean(true) -> 1;
+encode_boolean(false) -> 0;
+encode_boolean(B) when is_integer(B) -> B.
+
+decode_boolean(0) -> false;
+decode_boolean(I) when is_integer(I) -> true.
+
+
+%%
+%% Data field -> term() content representation
+%%
+%% Class IN RRs
+decode_data(Data, in, ?S_A,  _) ->
+    ?MATCH_ELSE_DECODE_ERROR(Data, <<A,B,C,D>>, {A,B,C,D});
+decode_data(Data, in, ?S_AAAA, _) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<A:16,B:16,C:16,D:16,E:16,F:16,G:16,H:16>>,
+       {A,B,C,D,E,F,G,H});
+decode_data(Data, in, ?S_WKS, _) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<A,B,C,D,Proto,BitMap/binary>>,
+       {{A,B,C,D},Proto,BitMap});
+%%
+decode_data(Data, Class, Type, Buffer) ->
+    if
+        is_integer(Class) -> % Raw class
+            Data;
+        is_atom(Class) -> % Symbolic class, i.e: known
+            decode_data(Data, Type, Buffer)
+    end.
+%%
+%%
+%% Standard RRs (any class)
+decode_data(Data, ?S_SOA, Buffer) ->
+    {Data1,MName} = decode_name(Data, Buffer),
+    {Data2,RName} = decode_name(Data1, Buffer),
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data2,
+       <<Serial:32,Refresh:32/signed,Retry:32/signed,
+         Expiry:32/signed,Minimum:32>>,
+       {MName,RName,Serial,Refresh,Retry,Expiry,Minimum});
+decode_data(Data, ?S_NS,    Buffer) -> decode_domain(Data, Buffer);
+decode_data(Data, ?S_MD,    Buffer) -> decode_domain(Data, Buffer);
+decode_data(Data, ?S_MF,    Buffer) -> decode_domain(Data, Buffer);
+decode_data(Data, ?S_CNAME, Buffer) -> decode_domain(Data, Buffer);
+decode_data(Data, ?S_MB,    Buffer) -> decode_domain(Data, Buffer);
+decode_data(Data, ?S_MG,    Buffer) -> decode_domain(Data, Buffer);
+decode_data(Data, ?S_MR,    Buffer) -> decode_domain(Data, Buffer);
+decode_data(Data, ?S_PTR,   Buffer) -> decode_domain(Data, Buffer);
+decode_data(Data, ?S_NULL,  _)      -> Data;
+decode_data(Data, ?S_HINFO, _) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<CpuLen,CPU:CpuLen/binary,OsLen,OS:OsLen/binary>>,
+       {binary_to_list(CPU),binary_to_list(OS)});
+decode_data(Data, ?S_MINFO, Buffer) ->
+    {Data1,RM} = decode_name(Data, Buffer),
+    {Data2,EM} = decode_name(Data1, Buffer),
+    ?MATCH_ELSE_DECODE_ERROR(Data2, <<>>, {RM,EM});
+decode_data(Data, ?S_MX, Buffer) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<Prio:16,Dom/binary>>,
+       {Prio,decode_domain(Dom, Buffer)});
+decode_data(Data, ?S_SRV, Buffer) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<Prio:16,Weight:16,Port:16,Dom/binary>>,
+       {Prio,Weight,Port,decode_domain(Dom, Buffer)});
+decode_data(Data, ?S_NAPTR, Buffer) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<Order:16,Preference:16,Data1/binary>>,
+       begin
+           {Data2,Flags} = decode_string(Data1),
+           {Data3,Services} = decode_string(Data2),
+           {Data4,Regexp} = decode_characters(Data3, utf8),
+           Replacement = decode_domain(Data4, Buffer),
+           {Order,Preference,
+            inet_db:tolower(Flags),inet_db:tolower(Services),
+            Regexp,Replacement}
+       end);
+decode_data(Data, ?S_TXT, _) -> decode_txt(Data);
+decode_data(Data, ?S_SPF, _) -> decode_txt(Data);
+decode_data(Data, ?S_URI, _) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<Prio:16,Weight:16,Data1/binary>>, 1 =< byte_size(Data1),
+       begin
+           Target = binary_to_list(Data1),
+           {Prio,Weight,Target}
+       end);
+decode_data(Data, ?S_CAA, _) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<Flags:8,Data1/binary>>,
+       begin
+           {Data2,Tag} = decode_string(Data1),
+           ?MATCH_ELSE_DECODE_ERROR(
+              length(Tag),
+              L, 1 =< L andalso L =< 15,
+              begin
+                  Value = binary_to_list(Data2),
+                  {Flags,inet_db:tolower(Tag),Value}
+              end)
+       end);
+%%
+%% sofar unknown or non standard
+decode_data(Data, Type, _) when is_integer(Type) ->
+    Data.
+
+
+%% Array of strings
+%%
+decode_txt(<<>>) -> [];
+decode_txt(Bin) ->
+    {Rest,String} = decode_string(Bin),
+    [String|decode_txt(Rest)].
+
+decode_string(Data) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<Len,Bin:Len/binary,Rest/binary>>,
+       {Rest,binary_to_list(Bin)}).
+
+decode_characters(Data, Encoding) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<Len,Bin:Len/binary,Rest/binary>>,
+       {Rest,unicode:characters_to_list(Bin, Encoding)}).
+
+%% One domain name only, there must be nothing after
+%%
+decode_domain(Bin, Buffer) ->
+    ?MATCH_ELSE_DECODE_ERROR(decode_name(Bin, Buffer), {<<>>,Name}, Name).
+
+%% Domain name -> {RestBin,Name}
+%%
+decode_name(Bin, Buffer) ->
+    decode_name(Bin, Buffer, [], Bin, 0).
+
+%% Tail advances with Rest until the first indirection is followed
+%% then it stays put at that Rest.
+decode_name(_, Buffer, _Labels, _Tail, Cnt) when Cnt > byte_size(Buffer) ->
+    throw(?DECODE_ERROR); %% Insanity bailout - this must be a decode loop
+decode_name(<<0,Rest/binary>>, _Buffer, Labels, Tail, Cnt) ->
+    %% Root domain, we have all labels for the domain name
+    {if Cnt =/= 0 -> Tail; true -> Rest end,
+     decode_name_labels(Labels)};
+decode_name(<<0:2,Len:6,Label:Len/binary,Rest/binary>>,
+	     Buffer, Labels, Tail, Cnt) ->
+    %% One plain label here
+    decode_name(Rest, Buffer, [Label|Labels],
+		if Cnt =/= 0 -> Tail; true -> Rest end,
+		Cnt);
+decode_name(<<3:2,Ptr:14,Rest/binary>>, Buffer, Labels, Tail, Cnt) ->
+    %% Indirection - reposition in buffer and recurse
+    ?MATCH_ELSE_DECODE_ERROR(
+       Buffer,
+       <<_:Ptr/binary,Bin/binary>>,
+       decode_name(
+         Bin, Buffer, Labels,
+         if Cnt =/= 0 -> Tail; true -> Rest end,
+         Cnt+2)); % size of indirection pointer
+decode_name(_, _, _, _, _) -> throw(?DECODE_ERROR).
+
+%% Reverse list of labels (binaries) -> domain name (string)
+decode_name_labels([]) -> ".";
+decode_name_labels(Labels) ->
+    decode_name_labels(Labels, "").
+
+decode_name_labels([Label], Name) ->
+    decode_name_label(Label, Name);
+decode_name_labels([Label|Labels], Name) ->
+    decode_name_labels(Labels, "."++decode_name_label(Label, Name)).
+
+decode_name_label(Label, Name) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Label,
+       _, 1 =< byte_size(Label),
+       %% Empty label is only allowed for the root domain,
+       %% and that is handled above.
+       decode_name_label(Label, Name, byte_size(Label))).
+
+%% Decode $. and $\\ to become $\\ escaped characters
+%% in the string representation.
+-compile({inline, [decode_name_label/3]}).
+decode_name_label(_, Name, 0) -> Name;
+decode_name_label(Label, Name, N) ->
+    M = N-1,
+    case Label of
+	<<_:M/binary,($\\),_/binary>> ->
+	    decode_name_label(Label, "\\\\"++Name, M);
+	<<_:M/binary,($.),_/binary>> ->
+	    decode_name_label(Label, "\\."++Name, M);
+	<<_:M/binary,C,_/binary>> ->
+	    decode_name_label(Label, [C|Name], M);
+	_ ->
+	    %% This should not happen but makes surrounding
+	    %% programming errors easier to locate.
+	    erlang:error(badarg, [Label,Name,N])
+    end.
+
+%%
+%% Data field -> {binary(),NewCompressionTable}
+%%
+%% Class IN RRs
+encode_data(Comp, _, ?S_A, in, Addr) ->
+    {A,B,C,D} = Addr,
+    {<<A,B,C,D>>,Comp};
+encode_data(Comp, _, ?S_AAAA, in, Addr) ->
+    {A,B,C,D,E,F,G,H} = Addr,
+    {<<A:16,B:16,C:16,D:16,E:16,F:16,G:16,H:16>>,Comp};
+encode_data(Comp, _, ?S_WKS, in, Data) ->
+    {{A,B,C,D},Proto,BitMap} = Data,
+    BitMapBin = iolist_to_binary(BitMap),
+    {<<A,B,C,D,Proto,BitMapBin/binary>>,Comp};
+%% OPT pseudo-RR (of no class) - should not take this way;
+%% this must be a #dns_rr{type = ?S_OPT} instead of a #dns_rr_opt{},
+%% so good luck getting in particular Class and TTL right...
+encode_data(Comp, _, ?S_OPT, _UdpPayloadSize, Data) ->
+    encode_data(Comp, Data);
+%%
+encode_data(Comp, Pos, Type, Class, Data) ->
+    if
+        is_integer(Class) ->
+            encode_data(Comp, Data);
+        is_atom(Class) -> % Known Class
+            encode_data(Comp, Pos, Type, Data)
+    end.
+%%
+%%
+%% Standard RRs (any class)
+encode_data(Comp, Pos, ?S_SOA, Data) ->
+    {MName,RName,Serial,Refresh,Retry,Expiry,Minimum} = Data,
+    {B1,Comp1} = encode_name(Comp, Pos, MName),
+    {B,Comp2} = encode_name(B1, Comp1, Pos+byte_size(B1), RName),
+    {<<B/binary,Serial:32,Refresh:32/signed,Retry:32/signed,
+      Expiry:32/signed,Minimum:32>>,
+     Comp2};
+encode_data(Comp, Pos, ?S_NS,    Domain) -> encode_name(Comp, Pos, Domain);
+encode_data(Comp, Pos, ?S_MD,    Domain) -> encode_name(Comp, Pos, Domain);
+encode_data(Comp, Pos, ?S_MF,    Domain) -> encode_name(Comp, Pos, Domain);
+encode_data(Comp, Pos, ?S_CNAME, Domain) -> encode_name(Comp, Pos, Domain);
+encode_data(Comp, Pos, ?S_MB,    Domain) -> encode_name(Comp, Pos, Domain);
+encode_data(Comp, Pos, ?S_MG,    Domain) -> encode_name(Comp, Pos, Domain);
+encode_data(Comp, Pos, ?S_MR,    Domain) -> encode_name(Comp, Pos, Domain);
+encode_data(Comp, Pos, ?S_PTR,   Domain) -> encode_name(Comp, Pos, Domain);
+encode_data(Comp, _,   ?S_NULL,  Data)   -> encode_data(Comp, Data);
+encode_data(Comp, _,   ?S_HINFO, Data) ->
+    {CPU,OS} = Data,
+    Bin = encode_string(iolist_to_binary(CPU)),
+    {encode_string(Bin, iolist_to_binary(OS)),Comp};
+encode_data(Comp, Pos, ?S_MINFO, Data) ->
+    {RM,EM} = Data,
+    {Bin,Comp1} = encode_name(Comp, Pos, RM),
+    encode_name(Bin, Comp1, Pos+byte_size(Bin), EM);
+encode_data(Comp, Pos, ?S_MX, Data) ->
+    {Pref,Exch} = Data,
+    encode_name(<<Pref:16>>, Comp, Pos+2, Exch);
+encode_data(Comp, Pos, ?S_SRV, Data) ->
+    {Prio,Weight,Port,Target} = Data,
+    encode_name(<<Prio:16,Weight:16,Port:16>>, Comp, Pos+2+2+2, Target);
+encode_data(Comp, Pos, ?S_NAPTR, Data) ->
+    {Order,Preference,Flags,Services,Regexp,Replacement} = Data,
+    B0 = <<Order:16,Preference:16>>,
+    B1 = encode_string(B0, iolist_to_binary(Flags)),
+    B2 = encode_string(B1, iolist_to_binary(Services)),
+    B3 = encode_string(B2, unicode:characters_to_binary(Regexp,
+							unicode, utf8)),
+    %% Bypass name compression (RFC 2915: section 2)
+    {B,_} = encode_name(B3, gb_trees:empty(), Pos+byte_size(B3), Replacement),
+    {B,Comp};
+encode_data(Comp, _, ?S_TXT, Data) -> {encode_txt(Data),Comp};
+encode_data(Comp, _, ?S_SPF, Data) -> {encode_txt(Data),Comp};
+encode_data(Comp, _, ?S_URI, Data) ->
+    {Prio,Weight,Target} = Data,
+    {<<Prio:16,Weight:16,(iolist_to_binary(Target))/binary>>,Comp};
+encode_data(Comp, _, ?S_CAA, Data)->
+    case Data of
+        {Flags,Tag,Value} ->
+            B0 = <<Flags:8>>,
+            B1 = encode_string(B0, iolist_to_binary(Tag)),
+            B2 = iolist_to_binary(Value),
+            {<<B1/binary,B2/binary>>,Comp};
+        _ ->
+            {encode_txt(Data),Comp}
+    end;
+%%
+%% sofar unknown or non standard
+encode_data(Comp, _Pos, Type, Data) when is_integer(Type) ->
+    encode_data(Comp, Data).
+%%
+%% Passthrough
+-compile({inline, [encode_data/2]}).
+encode_data(Comp, Data) ->
+    {iolist_to_binary(Data),Comp}.
+
+%% Array of strings
+%%
+encode_txt(Strings) ->
+    encode_txt(<<>>, Strings).
+%%
+encode_txt(Bin, []) -> Bin;
+encode_txt(Bin, [S|Ss]) ->
+    encode_txt(encode_string(Bin, iolist_to_binary(S)), Ss).
+
+%% Singular string
+%%
+encode_string(StringBin) ->
+    encode_string(<<>>, StringBin).
+%%
+encode_string(Bin, StringBin) ->
+    Size = byte_size(StringBin),
+    if Size =< 255 ->
+	    <<Bin/binary,Size,StringBin/binary>>
+    end.
+
+%% Domain name
+%%
+encode_name(Comp, Pos, Name) ->
+    encode_name(<<>>, Comp, Pos, Name).
+%%
+%% Bin = target binary
+%% Comp = compression lookup table; label list -> buffer position
+%% Pos = position in DNS message
+%% Name = domain name to encode
+%%
+%% The name compression does not make the case conversions
+%% it could. This means case will be preserved at the cost
+%% of missed compression opportunities. But if the encoded
+%% message use the same case for different instances of
+%% the same domain name there is no problem, and if not it is
+%% only compression that suffers. Furthermore encode+decode
+%% this way becomes an identity operation for any decoded
+%% DNS message which is nice for testing encode.
+%%
+encode_name(Bin0, Comp0, Pos, Name) ->
+    case encode_labels(Bin0, Comp0, Pos, name2labels(Name)) of
+	{Bin,_}=Result when byte_size(Bin) - byte_size(Bin0) =< 255 -> Result;
+	_ ->
+	    %% Fail on too long name
+	    erlang:error(badarg, [Bin0,Comp0,Pos,Name])
+    end.
+
+name2labels("") ->  [];
+name2labels(".") -> [];
+name2labels(Cs) ->  name2labels(<<>>, Cs).
+%%
+name2labels(Label, "") ->            [Label];
+name2labels(Label, ".") ->           [Label];
+name2labels(Label, "."++Cs) ->       [Label|name2labels(<<>>, Cs)];
+name2labels(Label, "\\"++[C|Cs]) ->  name2labels(Label, Cs, C);
+name2labels(Label, [C|Cs]) ->        name2labels(Label, Cs, C).
+%%
+-compile({inline, [name2labels/3]}).
+name2labels(Label, Cs, C) when is_integer(C), 0 =< C, C =< 255 ->
+    name2labels(<<Label/binary,C>>, Cs).
+
+%% Fail on empty or too long labels.
+encode_labels(Bin, Comp, _Pos, []) ->
+    {<<Bin/binary,0>>,Comp};
+encode_labels(Bin, Comp0, Pos, [L|Ls]=Labels)
+  when 1 =< byte_size(L), byte_size(L) =< 63 ->
+    case gb_trees:lookup(Labels, Comp0) of
+	none ->
+	    Comp = if Pos < (1 bsl 14) ->
+			   %% Just in case - compression
+			   %% pointers cannot reach further
+			   gb_trees:insert(Labels, Pos, Comp0);
+		      true -> Comp0
+		   end,
+	    Size = byte_size(L),
+	    encode_labels(<<Bin/binary,Size,L/binary>>,
+			  Comp, Pos+1+Size, Ls);
+	{value,Ptr} ->
+	    %% Name compression - point to already encoded name
+	    {<<Bin/binary,3:2,Ptr:14>>,Comp0}
+    end.

--- a/src/mdns_lite_inet_dns.hrl
+++ b/src/mdns_lite_inet_dns.hrl
@@ -1,0 +1,219 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+%%
+%% Defintion for Domain Name System
+%%
+
+%%
+%% Currently defined opcodes
+%%
+-define(QUERY,    16#0).          %% standard query
+-define(IQUERY,   16#1).	      %% inverse query 
+-define(STATUS,   16#2).	      %% nameserver status query 
+%% -define(xxx,   16#3)  %% 16#3 reserved
+%%  non standard
+-define(UPDATEA,  16#9).	       %% add resource record
+-define(UPDATED,  16#a).	       %% delete a specific resource record
+-define(UPDATEDA, 16#b).	       %% delete all nemed resource record
+-define(UPDATEM,  16#c).	       %% modify a specific resource record
+-define(UPDATEMA, 16#d).	       %% modify all named resource record
+
+-define(ZONEINIT, 16#e).	       %% initial zone transfer 
+-define(ZONEREF,  16#f).	       %% incremental zone referesh
+
+
+%%
+%% Currently defined response codes
+%%
+-define(NOERROR,  0).		%% no error
+-define(FORMERR,  1).		%% format error
+-define(SERVFAIL, 2).		%% server failure
+-define(NXDOMAIN, 3).		%% non existent domain
+-define(NOTIMP,	  4).		%% not implemented
+-define(REFUSED,  5).		%% query refused
+%%	non standard 
+-define(NOCHANGE, 16#f).		%% update failed to change db
+-define(BADVERS,  16).
+
+%%
+%% Type values for resources and queries
+%%
+-define(T_A,		1).		%% host address
+-define(T_NS,		2).		%% authoritative server
+-define(T_MD,		3).		%% mail destination
+-define(T_MF,		4).		%% mail forwarder
+-define(T_CNAME,	5).		%% connonical name
+-define(T_SOA,		6).		%% start of authority zone
+-define(T_MB,		7).		%% mailbox domain name
+-define(T_MG,		8).		%% mail group member
+-define(T_MR,		9).		%% mail rename name
+-define(T_NULL,		10).		%% null resource record
+-define(T_WKS,		11).		%% well known service
+-define(T_PTR,		12).		%% domain name pointer
+-define(T_HINFO,	13).		%% host information
+-define(T_MINFO,	14).		%% mailbox information
+-define(T_MX,		15).		%% mail routing information
+-define(T_TXT,		16).		%% text strings
+-define(T_AAAA,         28).            %% ipv6 address
+%% SRV (RFC 2052)
+-define(T_SRV,          33).            %% services
+%% NAPTR (RFC 2915)
+-define(T_NAPTR,        35).            %% naming authority pointer
+-define(T_OPT,          41).            %% EDNS pseudo-rr RFC2671(7)
+%% SPF (RFC 4408)
+-define(T_SPF,          99).            %% server policy framework
+%%      non standard
+-define(T_UINFO,	100).		%% user (finger) information
+-define(T_UID,		101).		%% user ID
+-define(T_GID,		102).		%% group ID
+-define(T_UNSPEC,	103).		%% Unspecified format (binary data)
+%%	Query type values which do not appear in resource records
+-define(T_AXFR,		252).		%% transfer zone of authority
+-define(T_MAILB,	253).		%% transfer mailbox records
+-define(T_MAILA,	254).		%% transfer mail agent records
+-define(T_ANY,		255).		%% wildcard match
+%% URI (RFC 7553)
+-define(T_URI,		256).		%% uniform resource identifier
+%% CAA (RFC 6844)
+-define(T_CAA,		257).		%% certification authority authorization
+
+%%
+%% Symbolic Type values for resources and queries
+%%
+-define(S_A,		a).		%% host address
+-define(S_NS,		ns).		%% authoritative server
+-define(S_MD,		md).		%% mail destination
+-define(S_MF,		mf).		%% mail forwarder
+-define(S_CNAME,	cname).		%% connonical name
+-define(S_SOA,		soa).		%% start of authority zone
+-define(S_MB,		mb).		%% mailbox domain name
+-define(S_MG,		mg).		%% mail group member
+-define(S_MR,		mr).		%% mail rename name
+-define(S_NULL,		null).		%% null resource record
+-define(S_WKS,		wks).		%% well known service
+-define(S_PTR,		ptr).		%% domain name pointer
+-define(S_HINFO,	hinfo).		%% host information
+-define(S_MINFO,	minfo).		%% mailbox information
+-define(S_MX,		mx).		%% mail routing information
+-define(S_TXT,		txt).		%% text strings
+-define(S_AAAA,         aaaa).          %% ipv6 address
+%% SRV (RFC 2052)
+-define(S_SRV,          srv).           %% services
+%% NAPTR (RFC 2915)
+-define(S_NAPTR,        naptr).         %% naming authority pointer
+-define(S_OPT,          opt).           %% EDNS pseudo-rr RFC2671(7)
+%% SPF (RFC 4408)
+-define(S_SPF,          spf).           %% server policy framework
+%%      non standard
+-define(S_UINFO,	uinfo).		%% user (finger) information
+-define(S_UID,		uid).		%% user ID
+-define(S_GID,		gid).		%% group ID
+-define(S_UNSPEC,	unspec).        %% Unspecified format (binary data)
+%%	Query type values which do not appear in resource records
+-define(S_AXFR,		axfr).		%% transfer zone of authority
+-define(S_MAILB,	mailb).		%% transfer mailbox records
+-define(S_MAILA,	maila).		%% transfer mail agent records
+-define(S_ANY,		any).		%% wildcard match
+%% URI (RFC 7553)
+-define(S_URI,		uri).		%% uniform resource identifier
+%% CAA (RFC 6844)
+-define(S_CAA,		caa).		%% certification authority authorization
+
+%%
+%% Values for class field
+%%
+
+-define(C_IN,		1).      	%% the arpa internet
+-define(C_CHAOS,	3).		%% for chaos net at MIT
+-define(C_HS,		4).		%% for Hesiod name server at MIT
+%%  Query class values which do not appear in resource records
+-define(C_ANY,		255).		%% wildcard match 
+
+
+%% indirection mask for compressed domain names
+-define(INDIR_MASK, 16#c0).
+
+%%
+%% Structure for query header, the order of the fields is machine and
+%% compiler dependent, in our case, the bits within a byte are assignd
+%% least significant first, while the order of transmition is most
+%% significant first.  This requires a somewhat confusing rearrangement.
+%%
+-record(dns_header, 
+	{
+	 id = 0,       %% ushort query identification number 
+	 %% byte F0
+	 qr = 0,       %% :1   response flag
+	 opcode = 0,   %% :4   purpose of message
+	 aa = 0,       %% :1   authoritive answer
+	 tc = 0,       %% :1   truncated message
+	 rd = 0,       %% :1   recursion desired 
+	 %% byte F1
+	 ra = 0,       %% :1   recursion available
+	 pr = 0,       %% :1   primary server required (non standard)
+	               %% :2   unused bits
+	 rcode = 0     %% :4   response code
+	}).
+
+-record(dns_rec,
+	{
+	 header,       %% dns_header record
+	 qdlist = [],  %% list of question entries
+	 anlist = [],  %% list of answer entries
+	 nslist = [],  %% list of authority entries
+	 arlist = []   %% list of resource entries
+	}).
+
+%% DNS resource record
+-record(dns_rr,
+	{
+	 domain = "",   %% resource domain
+	 type = any,    %% resource type
+	 class = in,    %% reource class
+	 cnt = 0,       %% access count
+	 ttl = 0,       %% time to live
+	 data = [],     %% raw data
+	  %%
+	 tm,            %% creation time
+         bm = [],       %% Bitmap storing domain character case information.
+         func = false   %% Was: Optional function calculating the data field.
+         %%                Now: cache-flush Class flag from mDNS RFC 6762
+	}).
+
+-define(DNS_UDP_PAYLOAD_SIZE, 1280).
+
+-record(dns_rr_opt,           %% EDNS RR OPT (RFC2671), dns_rr{type=opt}
+	{
+	  domain = "",        %% should be the root domain
+	  type = opt,
+	  udp_payload_size = ?DNS_UDP_PAYLOAD_SIZE, %% RFC2671(4.5 CLASS)
+	  ext_rcode = 0,      %% RFC2671(4.6 EXTENDED-RCODE)
+	  version = 0,        %% RFC2671(4.6 VERSION)
+	  z = 0,              %% RFC2671(4.6 Z)
+	  data = []           %% RFC2671(4.4)
+	 }).
+
+-record(dns_query,
+	{
+	 domain,                    %% query domain
+	 type,                      %% query type
+	 class,                     %% query class
+         unicast_response = false   %% mDNS RFC 6762 Class flag
+	 }).

--- a/src/mdns_lite_inet_dns_record_adts.hrl
+++ b/src/mdns_lite_inet_dns_record_adts.hrl
@@ -1,0 +1,497 @@
+
+%%
+%% Abstract Data Type functions for #dns_query{}
+%%
+%% -export([dns_query/1, dns_query/2,
+%%          make_dns_query/0, make_dns_query/1, make_dns_query/2, make_dns_query/3]).
+
+%% Split #dns_query{} into property list
+%%
+dns_query(#dns_query{domain=V1,type=V2,class=V3}) ->
+    [{domain,V1},{type,V2},{class,V3}].
+
+%% Get one field value from #dns_query{}
+%%
+dns_query(#dns_query{domain=V1}, domain) ->
+    V1;
+dns_query(#dns_query{type=V2}, type) ->
+    V2;
+dns_query(#dns_query{class=V3}, class) ->
+    V3;
+%% Map field name list to value list from #dns_query{}
+%%
+dns_query(#dns_query{}, []) ->
+    [];
+dns_query(#dns_query{domain=V1}=R, [domain|L]) ->
+    [V1|dns_query(R, L)];
+dns_query(#dns_query{type=V2}=R, [type|L]) ->
+    [V2|dns_query(R, L)];
+dns_query(#dns_query{class=V3}=R, [class|L]) ->
+    [V3|dns_query(R, L)].
+
+%% Generate default #dns_query{}
+%%
+make_dns_query() ->
+    #dns_query{}.
+
+%% Generate #dns_query{} from property list
+%%
+make_dns_query(L) when is_list(L) ->
+    make_dns_query(#dns_query{}, L).
+
+%% Generate #dns_query{} with one updated field
+%%
+make_dns_query(domain, V1) ->
+    #dns_query{domain=V1};
+make_dns_query(type, V2) ->
+    #dns_query{type=V2};
+make_dns_query(class, V3) ->
+    #dns_query{class=V3};
+%%
+%% Update #dns_query{} from property list
+%%
+make_dns_query(#dns_query{domain=V1,type=V2,class=V3}, L) when is_list(L) ->
+    do_make_dns_query(L, V1,V2,V3).
+do_make_dns_query([], V1,V2,V3) ->
+    #dns_query{domain=V1,type=V2,class=V3};
+do_make_dns_query([{domain,V1}|L], _,V2,V3) ->
+    do_make_dns_query(L, V1,V2,V3);
+do_make_dns_query([{type,V2}|L], V1,_,V3) ->
+    do_make_dns_query(L, V1,V2,V3);
+do_make_dns_query([{class,V3}|L], V1,V2,_) ->
+    do_make_dns_query(L, V1,V2,V3).
+
+%% Update one field of #dns_query{}
+%%
+make_dns_query(#dns_query{}=R, domain, V1) ->
+    R#dns_query{domain=V1};
+make_dns_query(#dns_query{}=R, type, V2) ->
+    R#dns_query{type=V2};
+make_dns_query(#dns_query{}=R, class, V3) ->
+    R#dns_query{class=V3}.
+
+
+%%
+%% Abstract Data Type functions for #dns_rr{}
+%%
+%% -export([dns_rr/1, dns_rr/2,
+%%          make_dns_rr/0, make_dns_rr/1, make_dns_rr/2, make_dns_rr/3]).
+
+%% Split #dns_rr{} into property list
+%%
+dns_rr(#dns_rr{domain=V1,type=V2,class=V3,ttl=V4,data=V5}) ->
+    [{domain,V1},{type,V2},{class,V3},{ttl,V4},{data,V5}].
+
+%% Get one field value from #dns_rr{}
+%%
+dns_rr(#dns_rr{domain=V1}, domain) ->
+    V1;
+dns_rr(#dns_rr{type=V2}, type) ->
+    V2;
+dns_rr(#dns_rr{class=V3}, class) ->
+    V3;
+dns_rr(#dns_rr{ttl=V4}, ttl) ->
+    V4;
+dns_rr(#dns_rr{data=V5}, data) ->
+    V5;
+%% Map field name list to value list from #dns_rr{}
+%%
+dns_rr(#dns_rr{}, []) ->
+    [];
+dns_rr(#dns_rr{domain=V1}=R, [domain|L]) ->
+    [V1|dns_rr(R, L)];
+dns_rr(#dns_rr{type=V2}=R, [type|L]) ->
+    [V2|dns_rr(R, L)];
+dns_rr(#dns_rr{class=V3}=R, [class|L]) ->
+    [V3|dns_rr(R, L)];
+dns_rr(#dns_rr{ttl=V4}=R, [ttl|L]) ->
+    [V4|dns_rr(R, L)];
+dns_rr(#dns_rr{data=V5}=R, [data|L]) ->
+    [V5|dns_rr(R, L)].
+
+%% Generate default #dns_rr{}
+%%
+make_dns_rr() ->
+    #dns_rr{}.
+
+%% Generate #dns_rr{} from property list
+%%
+make_dns_rr(L) when is_list(L) ->
+    make_dns_rr(#dns_rr{}, L).
+
+%% Generate #dns_rr{} with one updated field
+%%
+make_dns_rr(domain, V1) ->
+    #dns_rr{domain=V1};
+make_dns_rr(type, V2) ->
+    #dns_rr{type=V2};
+make_dns_rr(class, V3) ->
+    #dns_rr{class=V3};
+make_dns_rr(ttl, V4) ->
+    #dns_rr{ttl=V4};
+make_dns_rr(data, V5) ->
+    #dns_rr{data=V5};
+%%
+%% Update #dns_rr{} from property list
+%%
+make_dns_rr(#dns_rr{domain=V1,type=V2,class=V3,ttl=V4,data=V5}, L) when is_list(L) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5).
+do_make_dns_rr([], V1,V2,V3,V4,V5) ->
+    #dns_rr{domain=V1,type=V2,class=V3,ttl=V4,data=V5};
+do_make_dns_rr([{domain,V1}|L], _,V2,V3,V4,V5) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5);
+do_make_dns_rr([{type,V2}|L], V1,_,V3,V4,V5) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5);
+do_make_dns_rr([{class,V3}|L], V1,V2,_,V4,V5) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5);
+do_make_dns_rr([{ttl,V4}|L], V1,V2,V3,_,V5) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5);
+do_make_dns_rr([{data,V5}|L], V1,V2,V3,V4,_) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5).
+
+%% Update one field of #dns_rr{}
+%%
+make_dns_rr(#dns_rr{}=R, domain, V1) ->
+    R#dns_rr{domain=V1};
+make_dns_rr(#dns_rr{}=R, type, V2) ->
+    R#dns_rr{type=V2};
+make_dns_rr(#dns_rr{}=R, class, V3) ->
+    R#dns_rr{class=V3};
+make_dns_rr(#dns_rr{}=R, ttl, V4) ->
+    R#dns_rr{ttl=V4};
+make_dns_rr(#dns_rr{}=R, data, V5) ->
+    R#dns_rr{data=V5}.
+
+
+%%
+%% Abstract Data Type functions for #dns_rr_opt{}
+%%
+%% -export([dns_rr_opt/1, dns_rr_opt/2,
+%%          make_dns_rr_opt/0, make_dns_rr_opt/1, make_dns_rr_opt/2, make_dns_rr_opt/3]).
+
+%% Split #dns_rr_opt{} into property list
+%%
+dns_rr_opt(#dns_rr_opt{domain=V1,type=V2,udp_payload_size=V3,ext_rcode=V4,version=V5,z=V6,data=V7}) ->
+    [{domain,V1},{type,V2},{udp_payload_size,V3},{ext_rcode,V4},{version,V5},{z,V6},{data,V7}].
+
+%% Get one field value from #dns_rr_opt{}
+%%
+dns_rr_opt(#dns_rr_opt{domain=V1}, domain) ->
+    V1;
+dns_rr_opt(#dns_rr_opt{type=V2}, type) ->
+    V2;
+dns_rr_opt(#dns_rr_opt{udp_payload_size=V3}, udp_payload_size) ->
+    V3;
+dns_rr_opt(#dns_rr_opt{ext_rcode=V4}, ext_rcode) ->
+    V4;
+dns_rr_opt(#dns_rr_opt{version=V5}, version) ->
+    V5;
+dns_rr_opt(#dns_rr_opt{z=V6}, z) ->
+    V6;
+dns_rr_opt(#dns_rr_opt{data=V7}, data) ->
+    V7;
+%% Map field name list to value list from #dns_rr_opt{}
+%%
+dns_rr_opt(#dns_rr_opt{}, []) ->
+    [];
+dns_rr_opt(#dns_rr_opt{domain=V1}=R, [domain|L]) ->
+    [V1|dns_rr_opt(R, L)];
+dns_rr_opt(#dns_rr_opt{type=V2}=R, [type|L]) ->
+    [V2|dns_rr_opt(R, L)];
+dns_rr_opt(#dns_rr_opt{udp_payload_size=V3}=R, [udp_payload_size|L]) ->
+    [V3|dns_rr_opt(R, L)];
+dns_rr_opt(#dns_rr_opt{ext_rcode=V4}=R, [ext_rcode|L]) ->
+    [V4|dns_rr_opt(R, L)];
+dns_rr_opt(#dns_rr_opt{version=V5}=R, [version|L]) ->
+    [V5|dns_rr_opt(R, L)];
+dns_rr_opt(#dns_rr_opt{z=V6}=R, [z|L]) ->
+    [V6|dns_rr_opt(R, L)];
+dns_rr_opt(#dns_rr_opt{data=V7}=R, [data|L]) ->
+    [V7|dns_rr_opt(R, L)].
+
+%% Generate default #dns_rr_opt{}
+%%
+make_dns_rr_opt() ->
+    #dns_rr_opt{}.
+
+%% Generate #dns_rr_opt{} from property list
+%%
+make_dns_rr_opt(L) when is_list(L) ->
+    make_dns_rr_opt(#dns_rr_opt{}, L).
+
+%%
+%% Update #dns_rr_opt{} from property list
+%%
+make_dns_rr_opt(#dns_rr_opt{domain=V1,type=V2,udp_payload_size=V3,ext_rcode=V4,version=V5,z=V6,data=V7}, L) when is_list(L) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7).
+do_make_dns_rr_opt([], V1,V2,V3,V4,V5,V6,V7) ->
+    #dns_rr_opt{domain=V1,type=V2,udp_payload_size=V3,ext_rcode=V4,version=V5,z=V6,data=V7};
+do_make_dns_rr_opt([{domain,V1}|L], _,V2,V3,V4,V5,V6,V7) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
+do_make_dns_rr_opt([{type,V2}|L], V1,_,V3,V4,V5,V6,V7) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
+do_make_dns_rr_opt([{udp_payload_size,V3}|L], V1,V2,_,V4,V5,V6,V7) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
+do_make_dns_rr_opt([{ext_rcode,V4}|L], V1,V2,V3,_,V5,V6,V7) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
+do_make_dns_rr_opt([{version,V5}|L], V1,V2,V3,V4,_,V6,V7) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
+do_make_dns_rr_opt([{z,V6}|L], V1,V2,V3,V4,V5,_,V7) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
+do_make_dns_rr_opt([{data,V7}|L], V1,V2,V3,V4,V5,V6,_) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7).
+
+%% Update one field of #dns_rr_opt{}
+%%
+make_dns_rr_opt(#dns_rr_opt{}=R, domain, V1) ->
+    R#dns_rr_opt{domain=V1};
+make_dns_rr_opt(#dns_rr_opt{}=R, type, V2) ->
+    R#dns_rr_opt{type=V2};
+make_dns_rr_opt(#dns_rr_opt{}=R, udp_payload_size, V3) ->
+    R#dns_rr_opt{udp_payload_size=V3};
+make_dns_rr_opt(#dns_rr_opt{}=R, ext_rcode, V4) ->
+    R#dns_rr_opt{ext_rcode=V4};
+make_dns_rr_opt(#dns_rr_opt{}=R, version, V5) ->
+    R#dns_rr_opt{version=V5};
+make_dns_rr_opt(#dns_rr_opt{}=R, z, V6) ->
+    R#dns_rr_opt{z=V6};
+make_dns_rr_opt(#dns_rr_opt{}=R, data, V7) ->
+    R#dns_rr_opt{data=V7}.
+
+
+%%
+%% Abstract Data Type functions for #dns_header{}
+%%
+%% -export([header/1, header/2,
+%%          make_header/0, make_header/1, make_header/2, make_header/3]).
+
+%% Split #dns_header{} into property list
+%%
+header(#dns_header{id=V1,qr=V2,opcode=V3,aa=V4,tc=V5,rd=V6,ra=V7,pr=V8,rcode=V9}) ->
+    [{id,V1},{qr,V2},{opcode,V3},{aa,V4},{tc,V5},{rd,V6},{ra,V7},{pr,V8},{rcode,V9}].
+
+%% Get one field value from #dns_header{}
+%%
+header(#dns_header{id=V1}, id) ->
+    V1;
+header(#dns_header{qr=V2}, qr) ->
+    V2;
+header(#dns_header{opcode=V3}, opcode) ->
+    V3;
+header(#dns_header{aa=V4}, aa) ->
+    V4;
+header(#dns_header{tc=V5}, tc) ->
+    V5;
+header(#dns_header{rd=V6}, rd) ->
+    V6;
+header(#dns_header{ra=V7}, ra) ->
+    V7;
+header(#dns_header{pr=V8}, pr) ->
+    V8;
+header(#dns_header{rcode=V9}, rcode) ->
+    V9;
+%% Map field name list to value list from #dns_header{}
+%%
+header(#dns_header{}, []) ->
+    [];
+header(#dns_header{id=V1}=R, [id|L]) ->
+    [V1|header(R, L)];
+header(#dns_header{qr=V2}=R, [qr|L]) ->
+    [V2|header(R, L)];
+header(#dns_header{opcode=V3}=R, [opcode|L]) ->
+    [V3|header(R, L)];
+header(#dns_header{aa=V4}=R, [aa|L]) ->
+    [V4|header(R, L)];
+header(#dns_header{tc=V5}=R, [tc|L]) ->
+    [V5|header(R, L)];
+header(#dns_header{rd=V6}=R, [rd|L]) ->
+    [V6|header(R, L)];
+header(#dns_header{ra=V7}=R, [ra|L]) ->
+    [V7|header(R, L)];
+header(#dns_header{pr=V8}=R, [pr|L]) ->
+    [V8|header(R, L)];
+header(#dns_header{rcode=V9}=R, [rcode|L]) ->
+    [V9|header(R, L)].
+
+%% Generate default #dns_header{}
+%%
+make_header() ->
+    #dns_header{}.
+
+%% Generate #dns_header{} from property list
+%%
+make_header(L) when is_list(L) ->
+    make_header(#dns_header{}, L).
+
+%% Generate #dns_header{} with one updated field
+%%
+make_header(id, V1) ->
+    #dns_header{id=V1};
+make_header(qr, V2) ->
+    #dns_header{qr=V2};
+make_header(opcode, V3) ->
+    #dns_header{opcode=V3};
+make_header(aa, V4) ->
+    #dns_header{aa=V4};
+make_header(tc, V5) ->
+    #dns_header{tc=V5};
+make_header(rd, V6) ->
+    #dns_header{rd=V6};
+make_header(ra, V7) ->
+    #dns_header{ra=V7};
+make_header(pr, V8) ->
+    #dns_header{pr=V8};
+make_header(rcode, V9) ->
+    #dns_header{rcode=V9};
+%%
+%% Update #dns_header{} from property list
+%%
+make_header(#dns_header{id=V1,qr=V2,opcode=V3,aa=V4,tc=V5,rd=V6,ra=V7,pr=V8,rcode=V9}, L) when is_list(L) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9).
+do_make_header([], V1,V2,V3,V4,V5,V6,V7,V8,V9) ->
+    #dns_header{id=V1,qr=V2,opcode=V3,aa=V4,tc=V5,rd=V6,ra=V7,pr=V8,rcode=V9};
+do_make_header([{id,V1}|L], _,V2,V3,V4,V5,V6,V7,V8,V9) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9);
+do_make_header([{qr,V2}|L], V1,_,V3,V4,V5,V6,V7,V8,V9) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9);
+do_make_header([{opcode,V3}|L], V1,V2,_,V4,V5,V6,V7,V8,V9) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9);
+do_make_header([{aa,V4}|L], V1,V2,V3,_,V5,V6,V7,V8,V9) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9);
+do_make_header([{tc,V5}|L], V1,V2,V3,V4,_,V6,V7,V8,V9) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9);
+do_make_header([{rd,V6}|L], V1,V2,V3,V4,V5,_,V7,V8,V9) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9);
+do_make_header([{ra,V7}|L], V1,V2,V3,V4,V5,V6,_,V8,V9) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9);
+do_make_header([{pr,V8}|L], V1,V2,V3,V4,V5,V6,V7,_,V9) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9);
+do_make_header([{rcode,V9}|L], V1,V2,V3,V4,V5,V6,V7,V8,_) ->
+    do_make_header(L, V1,V2,V3,V4,V5,V6,V7,V8,V9).
+
+%% Update one field of #dns_header{}
+%%
+make_header(#dns_header{}=R, id, V1) ->
+    R#dns_header{id=V1};
+make_header(#dns_header{}=R, qr, V2) ->
+    R#dns_header{qr=V2};
+make_header(#dns_header{}=R, opcode, V3) ->
+    R#dns_header{opcode=V3};
+make_header(#dns_header{}=R, aa, V4) ->
+    R#dns_header{aa=V4};
+make_header(#dns_header{}=R, tc, V5) ->
+    R#dns_header{tc=V5};
+make_header(#dns_header{}=R, rd, V6) ->
+    R#dns_header{rd=V6};
+make_header(#dns_header{}=R, ra, V7) ->
+    R#dns_header{ra=V7};
+make_header(#dns_header{}=R, pr, V8) ->
+    R#dns_header{pr=V8};
+make_header(#dns_header{}=R, rcode, V9) ->
+    R#dns_header{rcode=V9}.
+
+
+%%
+%% Abstract Data Type functions for #dns_rec{}
+%%
+%% -export([msg/1, msg/2,
+%%          make_msg/0, make_msg/1, make_msg/2, make_msg/3]).
+
+%% Split #dns_rec{} into property list
+%%
+msg(#dns_rec{header=V1,qdlist=V2,anlist=V3,nslist=V4,arlist=V5}) ->
+    [{header,V1},{qdlist,V2},{anlist,V3},{nslist,V4},{arlist,V5}].
+
+%% Get one field value from #dns_rec{}
+%%
+msg(#dns_rec{header=V1}, header) ->
+    V1;
+msg(#dns_rec{qdlist=V2}, qdlist) ->
+    V2;
+msg(#dns_rec{anlist=V3}, anlist) ->
+    V3;
+msg(#dns_rec{nslist=V4}, nslist) ->
+    V4;
+msg(#dns_rec{arlist=V5}, arlist) ->
+    V5;
+%% Map field name list to value list from #dns_rec{}
+%%
+msg(#dns_rec{}, []) ->
+    [];
+msg(#dns_rec{header=V1}=R, [header|L]) ->
+    [V1|msg(R, L)];
+msg(#dns_rec{qdlist=V2}=R, [qdlist|L]) ->
+    [V2|msg(R, L)];
+msg(#dns_rec{anlist=V3}=R, [anlist|L]) ->
+    [V3|msg(R, L)];
+msg(#dns_rec{nslist=V4}=R, [nslist|L]) ->
+    [V4|msg(R, L)];
+msg(#dns_rec{arlist=V5}=R, [arlist|L]) ->
+    [V5|msg(R, L)].
+
+%% Generate default #dns_rec{}
+%%
+make_msg() ->
+    #dns_rec{}.
+
+%% Generate #dns_rec{} from property list
+%%
+make_msg(L) when is_list(L) ->
+    make_msg(#dns_rec{}, L).
+
+%% Generate #dns_rec{} with one updated field
+%%
+make_msg(header, V1) ->
+    #dns_rec{header=V1};
+make_msg(qdlist, V2) ->
+    #dns_rec{qdlist=V2};
+make_msg(anlist, V3) ->
+    #dns_rec{anlist=V3};
+make_msg(nslist, V4) ->
+    #dns_rec{nslist=V4};
+make_msg(arlist, V5) ->
+    #dns_rec{arlist=V5};
+%%
+%% Update #dns_rec{} from property list
+%%
+make_msg(#dns_rec{header=V1,qdlist=V2,anlist=V3,nslist=V4,arlist=V5}, L) when is_list(L) ->
+    do_make_msg(L, V1,V2,V3,V4,V5).
+do_make_msg([], V1,V2,V3,V4,V5) ->
+    #dns_rec{header=V1,qdlist=V2,anlist=V3,nslist=V4,arlist=V5};
+do_make_msg([{header,V1}|L], _,V2,V3,V4,V5) ->
+    do_make_msg(L, V1,V2,V3,V4,V5);
+do_make_msg([{qdlist,V2}|L], V1,_,V3,V4,V5) ->
+    do_make_msg(L, V1,V2,V3,V4,V5);
+do_make_msg([{anlist,V3}|L], V1,V2,_,V4,V5) ->
+    do_make_msg(L, V1,V2,V3,V4,V5);
+do_make_msg([{nslist,V4}|L], V1,V2,V3,_,V5) ->
+    do_make_msg(L, V1,V2,V3,V4,V5);
+do_make_msg([{arlist,V5}|L], V1,V2,V3,V4,_) ->
+    do_make_msg(L, V1,V2,V3,V4,V5).
+
+%% Update one field of #dns_rec{}
+%%
+make_msg(#dns_rec{}=R, header, V1) ->
+    R#dns_rec{header=V1};
+make_msg(#dns_rec{}=R, qdlist, V2) ->
+    R#dns_rec{qdlist=V2};
+make_msg(#dns_rec{}=R, anlist, V3) ->
+    R#dns_rec{anlist=V3};
+make_msg(#dns_rec{}=R, nslist, V4) ->
+    R#dns_rec{nslist=V4};
+make_msg(#dns_rec{}=R, arlist, V5) ->
+    R#dns_rec{arlist=V5}.
+
+%% Record type index
+%%
+record_adts(#dns_query{}) ->
+    dns_query;
+record_adts(#dns_rr{}) ->
+    dns_rr;
+record_adts(#dns_rr_opt{}) ->
+    dns_rr_opt;
+record_adts(#dns_header{}) ->
+    header;
+record_adts(#dns_rec{}) ->
+    msg;
+record_adts(_) -> undefined.

--- a/src/mdns_lite_inet_int.hrl
+++ b/src/mdns_lite_inet_int.hrl
@@ -1,0 +1,450 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+%%----------------------------------------------------------------------------
+%% Interface constants.
+%% 
+%% This section must be "identical" to the corresponding in inet_drv.c
+%% 
+
+%% family codes to open
+-define(INET_AF_UNSPEC,       0).
+-define(INET_AF_INET,         1).
+-define(INET_AF_INET6,        2).
+-define(INET_AF_ANY,          3). % Fake for ANY in any address family
+-define(INET_AF_LOOPBACK,     4). % Fake for LOOPBACK in any address family
+-define(INET_AF_LOCAL,        5). % For Unix Domain address family
+-define(INET_AF_UNDEFINED,    6). % For any unknown address family
+
+%% type codes to open and gettype - INET_REQ_GETTYPE
+-define(INET_TYPE_STREAM,     1).
+-define(INET_TYPE_DGRAM,      2).
+-define(INET_TYPE_SEQPACKET,  3).
+
+%% socket modes, INET_LOPT_MODE
+-define(INET_MODE_LIST,	      0).
+-define(INET_MODE_BINARY,     1).
+
+%% deliver mode, INET_LOPT_DELIVER
+-define(INET_DELIVER_PORT,    0).
+-define(INET_DELIVER_TERM,    1).
+
+%% active socket, INET_LOPT_ACTIVE
+-define(INET_PASSIVE, 0).
+-define(INET_ACTIVE,  1).
+-define(INET_ONCE,    2). % Active once then passive
+-define(INET_MULTI,   3). % Active N then passive
+
+%% state codes (getstatus, INET_REQ_GETSTATUS)
+-define(INET_F_OPEN,         16#0001).
+-define(INET_F_BOUND,        16#0002).
+-define(INET_F_ACTIVE,       16#0004).
+-define(INET_F_LISTEN,       16#0008).
+-define(INET_F_CON,          16#0010).
+-define(INET_F_ACC,          16#0020).
+-define(INET_F_LST,          16#0040).
+-define(INET_F_BUSY,         16#0080).
+
+%% request codes (erlang:port_control/3)
+-define(INET_REQ_OPEN,          1).
+-define(INET_REQ_CLOSE,         2).
+-define(INET_REQ_CONNECT,       3).
+-define(INET_REQ_PEER,          4).
+-define(INET_REQ_NAME,          5).
+-define(INET_REQ_BIND,          6).
+-define(INET_REQ_SETOPTS,       7).
+-define(INET_REQ_GETOPTS,       8).
+-define(INET_REQ_GETIX,         9).
+%% -define(INET_REQ_GETIF,      10). OBSOLETE
+-define(INET_REQ_GETSTAT,       11).
+-define(INET_REQ_GETHOSTNAME,   12).
+-define(INET_REQ_FDOPEN,        13).
+-define(INET_REQ_GETFD,         14).
+-define(INET_REQ_GETTYPE,       15).
+-define(INET_REQ_GETSTATUS,     16).
+-define(INET_REQ_GETSERVBYNAME, 17).
+-define(INET_REQ_GETSERVBYPORT, 18).
+-define(INET_REQ_SETNAME,       19).
+-define(INET_REQ_SETPEER,       20).
+-define(INET_REQ_GETIFLIST,     21).
+-define(INET_REQ_IFGET,         22).
+-define(INET_REQ_IFSET,         23).
+-define(INET_REQ_SUBSCRIBE,     24).
+-define(INET_REQ_GETIFADDRS,    25).
+-define(INET_REQ_ACCEPT,        26).
+-define(INET_REQ_LISTEN,        27).
+-define(INET_REQ_IGNOREFD,      28).
+-define(INET_REQ_GETLADDRS,     29).
+-define(INET_REQ_GETPADDRS,     30).
+
+%% TCP requests
+%%-define(TCP_REQ_ACCEPT,         40). MOVED
+%%-define(TCP_REQ_LISTEN,         41). MERGED
+-define(TCP_REQ_RECV,           42).
+-define(TCP_REQ_UNRECV,         43).
+-define(TCP_REQ_SHUTDOWN,       44).
+-define(TCP_REQ_SENDFILE,       45).
+
+%% UDP and SCTP requests
+-define(PACKET_REQ_RECV,        60).
+%%-define(SCTP_REQ_LISTEN,        61). MERGED
+-define(SCTP_REQ_BINDX,	        62). %% Multi-home SCTP bind
+-define(SCTP_REQ_PEELOFF,       63).
+
+%% subscribe codes, INET_REQ_SUBSCRIBE
+-define(INET_SUBS_EMPTY_OUT_Q,  1).
+
+%% reply codes for *_REQ_*
+-define(INET_REP_ERROR,    0).
+-define(INET_REP_OK,       1).
+-define(INET_REP,          2).
+
+%% INET, TCP and UDP options:
+-define(INET_OPT_REUSEADDR,      0).
+-define(INET_OPT_KEEPALIVE,      1).
+-define(INET_OPT_DONTROUTE,      2).
+-define(INET_OPT_LINGER,         3).
+-define(INET_OPT_BROADCAST,      4).
+-define(INET_OPT_OOBINLINE,      5).
+-define(INET_OPT_SNDBUF,         6).
+-define(INET_OPT_RCVBUF,         7).
+-define(INET_OPT_PRIORITY,       8).
+-define(INET_OPT_TOS,            9).
+-define(TCP_OPT_NODELAY,         10).
+-define(UDP_OPT_MULTICAST_IF,    11).
+-define(UDP_OPT_MULTICAST_TTL,   12).
+-define(UDP_OPT_MULTICAST_LOOP,  13).
+-define(UDP_OPT_ADD_MEMBERSHIP,  14).
+-define(UDP_OPT_DROP_MEMBERSHIP, 15).
+-define(INET_OPT_IPV6_V6ONLY,    16).
+% "Local" options: codes start from 20:
+-define(INET_LOPT_BUFFER,        20).
+-define(INET_LOPT_HEADER,        21).
+-define(INET_LOPT_ACTIVE,        22).
+-define(INET_LOPT_PACKET,        23).
+-define(INET_LOPT_MODE,          24).
+-define(INET_LOPT_DELIVER,       25).
+-define(INET_LOPT_EXITONCLOSE,   26).
+-define(INET_LOPT_TCP_HIWTRMRK,  27).
+-define(INET_LOPT_TCP_LOWTRMRK,  28).
+-define(INET_LOPT_TCP_SEND_TIMEOUT, 30).
+-define(INET_LOPT_TCP_DELAY_SEND,   31).
+-define(INET_LOPT_PACKET_SIZE,   32).
+-define(INET_LOPT_READ_PACKETS,  33).
+-define(INET_OPT_RAW,            34).
+-define(INET_LOPT_TCP_SEND_TIMEOUT_CLOSE, 35).
+-define(INET_LOPT_MSGQ_HIWTRMRK,  36).
+-define(INET_LOPT_MSGQ_LOWTRMRK,  37).
+-define(INET_LOPT_NETNS,          38).
+-define(INET_LOPT_TCP_SHOW_ECONNRESET, 39).
+-define(INET_LOPT_LINE_DELIM,     40).
+-define(INET_OPT_TCLASS,          41).
+-define(INET_OPT_BIND_TO_DEVICE,  42).
+-define(INET_OPT_RECVTOS,         43).
+-define(INET_OPT_RECVTCLASS,      44).
+-define(INET_OPT_PKTOPTIONS,      45).
+-define(INET_OPT_TTL,             46).
+-define(INET_OPT_RECVTTL,         47).
+-define(TCP_OPT_NOPUSH,           48).
+% Specific SCTP options: separate range:
+-define(SCTP_OPT_RTOINFO,	 	100).
+-define(SCTP_OPT_ASSOCINFO,	 	101).
+-define(SCTP_OPT_INITMSG,	 	102).
+-define(SCTP_OPT_AUTOCLOSE,	 	103).
+-define(SCTP_OPT_NODELAY,		104).
+-define(SCTP_OPT_DISABLE_FRAGMENTS,	105).
+-define(SCTP_OPT_I_WANT_MAPPED_V4_ADDR, 106).
+-define(SCTP_OPT_MAXSEG,		107).
+-define(SCTP_OPT_SET_PEER_PRIMARY_ADDR, 108).
+-define(SCTP_OPT_PRIMARY_ADDR,		109).
+-define(SCTP_OPT_ADAPTATION_LAYER,	110).
+-define(SCTP_OPT_PEER_ADDR_PARAMS,	111).
+-define(SCTP_OPT_DEFAULT_SEND_PARAM,	112).
+-define(SCTP_OPT_EVENTS,		113).
+-define(SCTP_OPT_DELAYED_ACK_TIME,	114).
+-define(SCTP_OPT_STATUS,		115).
+-define(SCTP_OPT_GET_PEER_ADDR_INFO,	116).
+
+%% interface options, INET_REQ_IFGET and INET_REQ_IFSET
+-define(INET_IFOPT_ADDR,      1).
+-define(INET_IFOPT_BROADADDR, 2).
+-define(INET_IFOPT_DSTADDR,   3).
+-define(INET_IFOPT_MTU,       4).
+-define(INET_IFOPT_NETMASK,   5).
+-define(INET_IFOPT_FLAGS,     6).
+-define(INET_IFOPT_HWADDR,    7). %% where support (e.g linux)
+
+%% packet byte values, INET_LOPT_PACKET
+-define(TCP_PB_RAW,     0).
+-define(TCP_PB_1,       1).
+-define(TCP_PB_2,       2).
+-define(TCP_PB_4,       3).
+-define(TCP_PB_ASN1,    4).
+-define(TCP_PB_RM,      5).
+-define(TCP_PB_CDR,     6).
+-define(TCP_PB_FCGI,    7).
+-define(TCP_PB_LINE_LF, 8).
+-define(TCP_PB_TPKT,    9).
+-define(TCP_PB_HTTP,    10).
+-define(TCP_PB_HTTPH,   11).
+-define(TCP_PB_SSL_TLS, 12).
+-define(TCP_PB_HTTP_BIN,13).
+-define(TCP_PB_HTTPH_BIN,14).
+
+
+%% getstat, INET_REQ_GETSTAT
+-define(INET_STAT_RECV_CNT,  1).
+-define(INET_STAT_RECV_MAX,  2).
+-define(INET_STAT_RECV_AVG,  3).
+-define(INET_STAT_RECV_DVI,  4).
+-define(INET_STAT_SEND_CNT,  5).
+-define(INET_STAT_SEND_MAX,  6).
+-define(INET_STAT_SEND_AVG,  7).
+-define(INET_STAT_SEND_PEND, 8).
+-define(INET_STAT_RECV_OCT,  9).
+-define(INET_STAT_SEND_OCT,  10).
+
+%% interface stuff, INET_IFOPT_FLAGS
+-define(INET_IFNAMSIZ,          16).
+-define(INET_IFF_UP,            16#0001).
+-define(INET_IFF_BROADCAST,     16#0002).
+-define(INET_IFF_LOOPBACK,      16#0004).
+-define(INET_IFF_POINTTOPOINT,  16#0008).
+-define(INET_IFF_RUNNING,       16#0010).
+-define(INET_IFF_MULTICAST,     16#0020).
+%%
+-define(INET_IFF_DOWN,          16#0100).
+-define(INET_IFF_NBROADCAST,    16#0200).
+-define(INET_IFF_NPOINTTOPOINT, 16#0800).
+
+%% SCTP Flags for "sctp_sndrcvinfo":
+%% INET_REQ_SETOPTS:SCTP_OPT_DEFAULT_SEND_PARAM
+-define(SCTP_FLAG_UNORDERED, 1). 	% sctp_unordered
+-define(SCTP_FLAG_ADDR_OVER, 2). 	% sctp_addr_over
+-define(SCTP_FLAG_ABORT,     4). 	% sctp_abort
+-define(SCTP_FLAG_EOF,	     8). 	% sctp_eof
+-define(SCTP_FLAG_SNDALL,   16). 	% sctp_sndall, NOT YET IMPLEMENTED.
+
+%% SCTP Flags for "sctp_paddrparams", and the corresp Atoms:
+-define(SCTP_FLAG_HB_ENABLE,		1).	% sctp_hb_enable
+-define(SCTP_FLAG_HB_DISABLE,		2).	% sctp_hb_disable
+-define(SCTP_FLAG_HB_DEMAND,		4).	% sctp_hb_demand
+-define(SCTP_FLAG_PMTUD_ENABLE,		8).	% sctp_pmtud_enable
+-define(SCTP_FLAG_PMTUD_DISABLE,       16).	% sctp_pmtud_disable
+-define(SCTP_FLAG_SACKDELAY_ENABLE,    32).	% sctp_sackdelay_enable
+-define(SCTP_FLAG_SACKDELAY_DISABLE,   64).	% sctp_sackdelay_disable
+
+%%
+%% End of interface constants.
+%%----------------------------------------------------------------------------
+
+-define(LISTEN_BACKLOG, 5).     %% default backlog
+
+%% 5 secs need more ???
+-define(INET_CLOSE_TIMEOUT, 5000).
+
+%%
+%% Port/socket numbers: network standard functions
+%%
+-define(IPPORT_ECHO,             7).
+-define(IPPORT_DISCARD,          9).
+-define(IPPORT_SYSTAT,           11).
+-define(IPPORT_DAYTIME,          13).
+-define(IPPORT_NETSTAT,          15).
+-define(IPPORT_FTP,              21).
+-define(IPPORT_TELNET,           23).
+-define(IPPORT_SMTP,             25).
+-define(IPPORT_TIMESERVER,       37).
+-define(IPPORT_NAMESERVER,       42).
+-define(IPPORT_WHOIS,            43).
+-define(IPPORT_MTP,              57).
+
+%%
+%% Port/socket numbers: host specific functions
+%%
+-define(IPPORT_TFTP,             69).
+-define(IPPORT_RJE,              77).
+-define(IPPORT_FINGER,           79).
+-define(IPPORT_TTYLINK,          87).
+-define(IPPORT_SUPDUP,           95).
+
+%%
+%% UNIX TCP sockets
+%%
+-define(IPPORT_EXECSERVER,       512).
+-define(IPPORT_LOGINSERVER,      513).
+-define(IPPORT_CMDSERVER,        514).
+-define(IPPORT_EFSSERVER,        520).
+
+%%
+%% UNIX UDP sockets
+%%
+-define(IPPORT_BIFFUDP,          512).
+-define(IPPORT_WHOSERVER,        513).
+-define(IPPORT_ROUTESERVER,      520). %% 520+1 also used
+
+
+%%
+%% Ports < IPPORT_RESERVED are reserved for
+%% privileged processes (e.g. root).
+%% Ports > IPPORT_USERRESERVED are reserved
+%% for servers, not necessarily privileged.
+%%
+-define(IPPORT_RESERVED,         1024).
+-define(IPPORT_USERRESERVED,     5000).
+
+%% standard port for socks
+-define(IPPORT_SOCKS,           1080).
+
+%%
+%% Int to bytes
+%%
+-define(int8(X), [(X) band 16#ff]).
+
+-define(int16(X), [((X) bsr 8) band 16#ff, (X) band 16#ff]).
+
+-define(int24(X), [((X) bsr 16) band 16#ff,
+		   ((X) bsr 8) band 16#ff, (X) band 16#ff]).
+
+-define(int32(X), 
+	[((X) bsr 24) band 16#ff, ((X) bsr 16) band 16#ff,
+	 ((X) bsr 8) band 16#ff, (X) band 16#ff]).
+
+-define(int64(X),
+	[((X) bsr 56) band 16#ff, ((X) bsr 48) band 16#ff,
+	 ((X) bsr 40) band 16#ff, ((X) bsr 32) band 16#ff,
+	 ((X) bsr 24) band 16#ff, ((X) bsr 16) band 16#ff,
+	 ((X) bsr 8) band 16#ff, (X) band 16#ff]).
+
+-define(intAID(X), % For SCTP AssocID
+        ?int32(X)).
+
+%% Bytes to unsigned
+-define(u64(X7,X6,X5,X4,X3,X2,X1,X0), 
+	( ((X7) bsl 56) bor ((X6) bsl 48) bor ((X5) bsl 40) bor
+	  ((X4) bsl 32) bor ((X3) bsl 24) bor ((X2) bsl 16) bor 
+	  ((X1) bsl 8) bor (X0)  )).
+
+-define(u32(X3,X2,X1,X0), 
+	(((X3) bsl 24) bor ((X2) bsl 16) bor ((X1) bsl 8) bor (X0))).
+
+-define(u24(X2,X1,X0),
+	(((X2) bsl 16) bor ((X1) bsl 8) bor (X0))).
+
+-define(u16(X1,X0),
+	(((X1) bsl 8) bor (X0))).
+ 
+-define(u8(X0), (X0)).
+
+%% Bytes to signed
+-define(i32(X3,X2,X1,X0),
+        (?u32(X3,X2,X1,X0) - 
+         (if (X3) > 127 -> 16#100000000; true -> 0 end))).
+
+-define(i24(X2,X1,X0),
+        (?u24(X2,X1,X0) - 
+         (if (X2) > 127 -> 16#1000000; true -> 0 end))).
+	
+-define(i16(X1,X0),
+        (?u16(X1,X0) - 
+         (if (X1) > 127 -> 16#10000; true -> 0 end))).
+
+-define(i8(X0),
+	(?u8(X0) -
+	 (if (X0) > 127 -> 16#100; true -> 0 end))).
+
+%% macro for use in guard for checking ip address {A,B,C,D}
+-define(ip(A,B,C,D),
+	(((A) bor (B) bor (C) bor (D)) band (bnot 16#ff)) =:= 0).
+-define(ip(Addr),
+        ?ip(element(1, (Addr)), element(2, (Addr)),
+            element(3, (Addr)), element(4, (Addr)))).
+
+-define(ip6(A,B,C,D,E,F,G,H), 
+	(((A) bor (B) bor (C) bor (D) bor (E) bor (F) bor (G) bor (H)) 
+	 band (bnot 16#ffff)) =:= 0).
+-define(ip6(Addr),
+        ?ip6(element(1, (Addr)), element(2, (Addr)),
+             element(3, (Addr)), element(4, (Addr)),
+             element(5, (Addr)), element(6, (Addr)),
+             element(7, (Addr)), element(8, (Addr)))).
+
+-define(ether(A,B,C,D,E,F), 
+	(((A) bor (B) bor (C) bor (D) bor (E) bor (F)) 
+	 band (bnot 16#ff)) =:= 0).
+
+-define(port(P), (((P) band bnot 16#ffff) =:= 0)).
+
+%% default options (when inet_drv port is started)
+%%
+%% bufsz   = INET_MIN_BUFFER (8K)
+%% header  = 0
+%% packet  = 0 (raw)
+%% mode    = list
+%% deliver = term
+%% active  = false
+%%
+-record(connect_opts, 
+	{ 
+	  ifaddr,           %% don't bind explicitly, let connect decide
+	  port   = 0,       %% bind to port (default is dynamic port)
+	  fd     = -1,      %% fd >= 0 => already bound
+	  opts   = []       %% [{active,true}] added in inet:connect_options
+	 }).
+
+-record(listen_opts, 
+	{ 
+	  ifaddr,                    %% interpreted as 'any' in *_tcp.erl
+	  port   = 0,                %% bind to port (default is dynamic port)
+	  backlog = ?LISTEN_BACKLOG, %% backlog
+	  fd      = -1,              %% %% fd >= 0 => already bound
+	  opts   = []                %% [{active,true}] added in 
+	                             %% inet:listen_options
+	 }).
+
+-record(udp_opts,
+	{
+	  ifaddr,
+	  port   = 0,
+	  fd     = -1,
+	  opts   = [{active, true}]
+	 }).
+
+-define(SCTP_DEF_BUFSZ, 65536).
+-record(sctp_opts,
+	{
+	  ifaddr,
+	  port   = 0,
+	  fd	 = -1,
+	  type   = seqpacket,
+	  opts   = [{mode,	  binary},
+		    {buffer,	  ?SCTP_DEF_BUFSZ},
+		    {sndbuf,	  ?SCTP_DEF_BUFSZ},
+		    {recbuf,	  1024},
+		    {sctp_events, undefined}%,
+		    %%{active,      true}
+		   ]
+        }).
+
+%% The following Tags are purely internal, used for marking items in the
+%% send buffer:
+-define(SCTP_TAG_SEND_ANC_INITMSG,	0).
+-define(SCTP_TAG_SEND_ANC_PARAMS,	1).
+-define(SCTP_TAG_SEND_DATA,		2).

--- a/test/mdns_lite/table_test.exs
+++ b/test/mdns_lite/table_test.exs
@@ -74,7 +74,7 @@ defmodule MdnsLite.TableTest do
   end
 
   test "responds to a unicast A request" do
-    query = dns_query(domain: 'nerves-21a5.local', type: :a, class: 32769)
+    query = dns_query(domain: 'nerves-21a5.local', type: :a, class: :in, unicast_response: true)
 
     result = %{
       answer: [
@@ -93,7 +93,7 @@ defmodule MdnsLite.TableTest do
   end
 
   test "ignores A request for someone else" do
-    query = dns_query(domain: 'someone-else.local', type: :a, class: 32769)
+    query = dns_query(domain: 'someone-else.local', type: :a, class: :in, unicast_response: true)
 
     assert do_query(query) == %{answer: [], additional: []}
   end


### PR DESCRIPTION
This fixes issues with handling the unicast bit when using OTP's
built-in DNS record decoder. Before Erlang/OTP 24.1.2, the DNS decoder
decoded TXT and SRV records even if it didn't recognize the record's
class. Since the mDNS's unicast response bit uses the high bit of the
class field, this was convenient. OTP 24.1.2 fixed some issues and ended
up getting pickier on what it encoded and decoded. On the bright side,
the mDNS unicast response bit is supported now.

This commit updates MdnsLite to support the new :inet_dns updates.
Rather than trying to deal with pre-OTP 24.1.2 behavior, the OTP 24.1.2
behavior and the new support, this commit vendors the encode and decode
code.

All DNS message encoding and decoding is routed through `MdnsLite.DNS`
now. Thorough DNS testing of the decoder and encoder is in OTP. This
contains spot checks for mDNS.

Fixes #59.
