### PR TITLE
Fix DNS bridge failure due to unpreserved rd field

### DIFF
--- a/lib/mdns_lite/dns_bridge.ex
+++ b/lib/mdns_lite/dns_bridge.ex
@@ -98,13 +98,13 @@ defmodule MdnsLite.DNSBridge do
   defp send_response(
          qdlist,
          result,
-         dns_rec(header: dns_header(id: id)),
+         dns_rec(header: dns_header(id: id, opcode: opcode, rd: rd)),
          {dest_address, dest_port},
          state
        ) do
     packet =
       dns_rec(
-        header: dns_header(id: id, qr: true, aa: true),
+        header: dns_header(id: id, qr: true, opcode: opcode, aa: true, rd: rd, rcode: 0),
         # Query list. Must be empty according to RFC 6762 Section 6.
         qdlist: qdlist,
         # A list of answer entries. Can be empty.


### PR DESCRIPTION
OTP 25's DNS resolver checks that the rd field is preserved in DNS
responses. It turns out that that DNS bridge was not preserving it and
this caused its responses to be discarded.

This fixes the issue. It also preserves opcode and sets rcode. Both of
these default to the right value, but if OTP ever changes the default
mdns_lite shouldn't break.
