### PR TITLE
add get_by_mdns/2

### DIFF
--- a/lib/mdns_lite.ex
+++ b/lib/mdns_lite.ex
@@ -164,6 +164,25 @@ defmodule MdnsLite do
     end
   end
 
+  @doc """
+  Lookup a PTR hostname using mDNS
+
+  The hostname should be a .local name since the query only goes out via mDNS.
+  On success, a domain is returned.
+  """
+  @spec get_by_mdns(String.t(), non_neg_integer()) :: any()
+  def get_by_mdns(hostname, timeout \\ @default_timeout) do
+    q = MdnsLite.DNS.dns_query(class: :in, type: :ptr, domain: to_charlist(hostname))
+
+    case query(q, timeout) do
+      %{answer: [first | _]} ->
+        {:ok, dns_rr(first, :domain)}
+
+      %{answer: []} ->
+        {:error, :nxdomain}
+    end
+  end
+
   defp to_addr(addr) when is_tuple(addr), do: addr
   defp to_addr(<<a, b, c, d>>), do: {a, b, c, d}
 


### PR DESCRIPTION
The current does not work with `PTR` (such as the `_elg._tcp.local` used by https://github.com/lawik/keylight). This PR adds a new function `get_by_mdns` that supports looking up `PTR` records.

Open questions and thoughts:
- The name and docs of this function are inaccurate/confusing because I don't fully understand MDNS, they should be updated before merging
- Should this be combined with `gethostbyname` somehow? i.e. by expanding `gethostbyname` to support both types of queries?