### PR TITLE
Bulletproof stopping responders when the net is down

### DIFF
--- a/lib/mdns_lite/responder.ex
+++ b/lib/mdns_lite/responder.ex
@@ -89,6 +89,11 @@ defmodule MdnsLite.Responder do
   @spec stop_server(String.t(), :inet.ip_address()) :: :ok
   def stop_server(ifname, address) do
     GenServer.stop(via_name({ifname, address}))
+  catch
+    {:exit, {:noproc, _}} ->
+      # Ignore if the server already stopped. It already exited due to the
+      # network going down.
+      :ok
   end
 
   ##############################################################################


### PR DESCRIPTION
Sometimes the respondor figures it out first. In this case, the call to
stop it shouldn't exit.
