### PR TITLE
Add "__unknown" excluded interface

### DIFF
--- a/lib/mdns_lite/options.ex
+++ b/lib/mdns_lite/options.ex
@@ -74,7 +74,7 @@ defmodule MdnsLite.Options do
   @default_ttl 120
   @default_dns_ip {127, 0, 0, 53}
   @default_dns_port 53
-  @default_excluded_ifnames ["lo0", "lo", "ppp0", "wwan0"]
+  @default_excluded_ifnames ["lo0", "lo", "ppp0", "wwan0", "__unknown"]
   @default_ipv4_only true
 
   defstruct services: MapSet.new(),


### PR DESCRIPTION
VintageNet assigns this name when it cannot get link info about an interface. 

https://github.com/nerves-networking/vintage_net/blob/main/lib/vintage_net/interfaces_monitor.ex#L159-L160