### PR TITLE
Unset remaining ifaces when using `MdnsLite.InetMonitor`

### DIFF
--- a/lib/mdns_lite/core_monitor.ex
+++ b/lib/mdns_lite/core_monitor.ex
@@ -68,10 +68,10 @@ defmodule MdnsLite.CoreMonitor do
   @spec unset_remaining_ifnames(state(), [String.t()]) :: state()
   def unset_remaining_ifnames(state, new_ifnames) do
     Enum.reduce(known_ifnames(state), state, fn ifname, state ->
-      if ifname not in new_ifnames do
-        set_ip_list(state, ifname, [])
-      else
+      if ifname in new_ifnames do
         state
+      else
+        set_ip_list(state, ifname, [])
       end
     end)
   end

--- a/lib/mdns_lite/core_monitor.ex
+++ b/lib/mdns_lite/core_monitor.ex
@@ -65,6 +65,20 @@ defmodule MdnsLite.CoreMonitor do
     %{state | todo: []}
   end
 
+  def unset_remaining_ifnames(state, new_ifnames) do
+    Enum.reduce(known_ifnames(state), state, fn ifname, state ->
+      if ifname not in new_ifnames do
+        set_ip_list(state, ifname, [])
+      else
+        state
+      end
+    end)
+  end
+
+  defp known_ifnames(state) do
+    Map.keys(state.ip_list)
+  end
+
   defp compute_delta(old_list, new_list) do
     {old_list -- new_list, new_list -- old_list}
   end

--- a/lib/mdns_lite/core_monitor.ex
+++ b/lib/mdns_lite/core_monitor.ex
@@ -65,6 +65,7 @@ defmodule MdnsLite.CoreMonitor do
     %{state | todo: []}
   end
 
+  @spec unset_remaining_ifnames(state(), [String.t()]) :: state()
   def unset_remaining_ifnames(state, new_ifnames) do
     Enum.reduce(known_ifnames(state), state, fn ifname, state ->
       if ifname not in new_ifnames do

--- a/test/mdns_lite/core_monitor_test.exs
+++ b/test/mdns_lite/core_monitor_test.exs
@@ -68,4 +68,23 @@ defmodule MdnsLite.CoreMonitorTest do
              {MdnsLite.ResponderSupervisor, :start_child, ["eth0", {1, 2, 3, 4, 5, 6, 7, 8}]}
            ]
   end
+
+  test "remove unset ifnames" do
+    state =
+      CoreMonitor.init([])
+      |> CoreMonitor.set_ip_list("eth0", [{1, 2, 3, 4}, {1, 2, 3, 4, 5, 6, 7, 8}])
+      |> CoreMonitor.set_ip_list("wlan0", [{10, 11, 12, 13}, {14, 15, 16, 17}])
+      |> CoreMonitor.flush_todo_list()
+
+    state =
+      state
+      |> CoreMonitor.set_ip_list("wlan0", [{10, 11, 12, 13}])
+      |> CoreMonitor.unset_remaining_ifnames(["wlan0"])
+
+    # IPv4 filtering is on by default
+    assert state.todo == [
+             {MdnsLite.ResponderSupervisor, :stop_child, ["wlan0", {14, 15, 16, 17}]},
+             {MdnsLite.ResponderSupervisor, :stop_child, ["eth0", {1, 2, 3, 4}]}
+           ]
+  end
 end


### PR DESCRIPTION
When using `MdnsLite.InetMonitor` we check for all interfaces in an interval. Newly added interfaces will be recognized but when an interface goes down, the todo list of the `MdnsLite.CoreMonitor` does not get set empty, because we don't call `MdnsLite.CoreMonitor.set_ip_list/2` for the missing interface.

The PR adds a new function to remove the missing interfaces from the known state. You just have to supply a list of the interfaces which are currently up, so we can compare the list.

It is only relevant in `InetMonitor` because in `VintageNetMonitor` we get the explicit down information with the subscription.