### PR TITLE
Require Elixir 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,11 @@ latest: &latest
 
 tags:
   &tags [
-    1.18.2-erlang-27.2.1-alpine-3.21.2,
+    1.18.3-erlang-27.3.3-alpine-3.21.3,
     1.17.2-erlang-27.0.1-alpine-3.20.2,
     1.16.0-erlang-26.2.1-alpine-3.18.4,
     1.15.7-erlang-26.1.2-alpine-3.18.4,
-    1.14.5-erlang-25.3.2-alpine-3.18.0,
-    1.13.4-erlang-24.3.4-alpine-3.15.3
+    1.14.5-erlang-25.3.2-alpine-3.18.0
   ]
 
 jobs:

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule MdnsLite.MixProject do
     [
       app: :mdns_lite,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       docs: docs(),
       description: description(),


### PR DESCRIPTION
It's getting harder to support Elixir 1.13 and 1.14 is required for
Igniter. Therefore, bump the minimal supported Elixir version.
