### PR TITLE
Fix invalid mDNS port handling and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you need something custom, specify `:type` directly. Optional fields include
 `:id`, `:weight`, `:priority`, `:instance_name` and `:txt_payload`. An `:id` is
 needed to remove the service advertisement at runtime. If not specified,
 `:instance_name` is inherited from the top-level config.  A `:txt_payload` is a
-list of `"<key>=<value>"` string that will be advertised in a TXT DNS record
+list of `"<key>=<value>"` strings that will be advertised in a TXT DNS record
 corresponding to the service.
 
 See [`MdnsLite.Options`](https://hexdocs.pm/mdns_lite/MdnsLite.Options.html) for

--- a/lib/mdns_lite/options.ex
+++ b/lib/mdns_lite/options.ex
@@ -28,7 +28,7 @@ defmodule MdnsLite.Options do
       },
       %{
         id: :ssh_daemon,
-        instance_name: "More particular mDNS Lite Device"
+        instance_name: "More particular mDNS Lite Device",
         protocol: "ssh",
         transport: "tcp",
         port: 22
@@ -251,7 +251,7 @@ defmodule MdnsLite.Options do
     {:error, "Specify either 1. :protocol and :transport or 2. :type"}
   end
 
-  defp normalize_port(%{port: port}) when port >= 0 and port <= 65535, do: {:ok, port}
+  defp normalize_port(%{port: port}) when port >= 1 and port <= 65535, do: {:ok, port}
   defp normalize_port(_), do: {:error, "Specify a port"}
 
   @doc false

--- a/test/mdns_lite/options_test.exs
+++ b/test/mdns_lite/options_test.exs
@@ -149,6 +149,11 @@ defmodule MdnsLite.OptionsTest do
                {:error, "Specify a port"}
     end
 
+    test "port must be greater than zero" do
+      assert Options.normalize_service(%{id: :id, type: "_ssh._tcp", port: 0}) ==
+               {:error, "Specify a port"}
+    end
+
     test "converts protocol and transport to a type" do
       {:ok, normalized} =
         Options.normalize_service(%{id: :id, port: 22, protocol: "ssh", transport: "tcp"})


### PR DESCRIPTION
## Summary
- ensure mDNS service ports must be greater than zero during option normalization
- add a regression test covering zero-valued ports
- correct documentation typos in README and module configuration example

## Testing
- mix test *(fails: requires Hex/Hex.pm access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8767c084832db2daeb67a2844c3c