### PR TITLE
Bump vendored DNS parser

### DIFF
--- a/src/mdns_lite_inet_dns.erl
+++ b/src/mdns_lite_inet_dns.erl
@@ -1,21 +1,28 @@
-%% SPDX-FileCopyrightText: Ericsson AB 1997-2021. All Rights Reserved.
+%% SPDX-FileCopyrightText: Ericsson AB 1997-2025. All Rights Reserved.
 %%
 %% SPDX-License-Identifier: Apache-2.0
 %%
 -module(mdns_lite_inet_dns).
+-moduledoc false.
 
 %% Dns record encode/decode
 %%
 %% RFC 1035: Domain Names - Implementation and Specification
+%% RFC 1995: Incremental Zone Transfer in DNS
+%% RFC 1996: A Mechanism for Prompt Notification of Zone Changes (DNS NOTIFY)
+%% RFC 2136: Dynamic Updates in the Domain Name System (DNS UPDATE)
 %% RFC 2181: Clarifications to the DNS Specification
-%% RFC 2671: Extension Mechanisms for DNS (EDNS0)
 %% RFC 2782: A DNS RR for specifying the location of services (DNS SRV)
 %% RFC 2915: The Naming Authority Pointer (NAPTR) DNS Resource Rec
+%% RFC 5936: DNS Zone Transfer Protocol (AXFR)
 %% RFC 6488: DNS Certification Authority Authorization (CAA) Resource Record
-%% RFC 7553: The Uniform Resource Identifier (URI) DNS Resource Record
 %% RFC 6762: Multicast DNS
+%% RFC 6891: Extension Mechanisms for DNS (EDNS0)
+%% RFC 7553: The Uniform Resource Identifier (URI) DNS Resource Record
+%% RFC 8945: Secret Key Transaction Authentication for DNS (TSIG)
 
--export([decode/1, encode/1]).
+-export([decode/1, decode/2, encode/1, encode/2]).
+-export([decode_algname/1, encode_algname/1]).
 
 -import(lists, [reverse/1]).
 
@@ -97,6 +104,10 @@ lists_member(H, [H|_]) -> true;
 lists_member(H, [_|T]) -> lists_member(H, T).
 
 
+-define(in_range(Low, X, High), ((Low =< (X)) andalso ((X) =< High))).
+-define(is_decimal(X), (?in_range(0, (X), 9))).
+
+
 %% must match a clause in inet_res:query_nss_e?dns
 -define(DECODE_ERROR, formerr).
 
@@ -122,8 +133,10 @@ lists_member(H, [_|T]) -> lists_member(H, T).
            throw(?DECODE_ERROR)
    end).
 
-decode(Buffer) when is_binary(Buffer) ->
-    try do_decode(Buffer) of
+decode(Buffer) -> decode(Buffer, true). % Backwards compatible
+%%
+decode(Buffer, Mdns) when is_binary(Buffer), is_boolean(Mdns) ->
+    try do_decode(Buffer, Mdns) of
 	DnsRec ->
 	    {ok,DnsRec}
     catch
@@ -135,11 +148,14 @@ do_decode(<<Id:16,
 	   QR:1,Opcode:4,AA:1,TC:1,RD:1,
 	   RA:1,PR:1,_:2,Rcode:4,
 	   QdCount:16,AnCount:16,NsCount:16,ArCount:16,
-	   QdBuf/binary>>=Buffer) ->
-    {AnBuf,QdList,QdTC} = decode_query_section(QdBuf,QdCount,Buffer),
-    {NsBuf,AnList,AnTC} = decode_rr_section(AnBuf,AnCount,Buffer),
-    {ArBuf,NsList,NsTC} = decode_rr_section(NsBuf,NsCount,Buffer),
-    {Rest,ArList,ArTC} = decode_rr_section(ArBuf,ArCount,Buffer),
+	   QdBuf/binary>>=Buffer, Mdns) ->
+    {AnBuf,QdList,QdTC} = decode_query_section(QdBuf,QdCount,Buffer,Mdns),
+    {NsBuf,AnList,AnTC} =
+        decode_rr_section(AnBuf,AnCount,Buffer,{Opcode,Mdns}),
+    {ArBuf,NsList,NsTC} =
+        decode_rr_section(NsBuf,NsCount,Buffer,{Opcode,Mdns}),
+    {Rest,ArList,ArTC} =
+        decode_rr_section(ArBuf,ArCount,Buffer,{Opcode,Mdns}),
     ?MATCH_ELSE_DECODE_ERROR(
        Rest,
        <<>>,
@@ -171,40 +187,40 @@ do_decode(<<Id:16,
                            arlist=ArList}
               end)
        end);
-do_decode(_) ->
+do_decode(_, _) ->
     %% DNS message does not even match header
     throw(?DECODE_ERROR).
 
-decode_query_section(Bin, N, Buffer) ->
-    decode_query_section(Bin, N, Buffer, []).
+decode_query_section(Bin, N, Buffer, Mdns) ->
+    decode_query_section(Bin, N, Buffer, Mdns, []).
 
-decode_query_section(<<>>=Rest, N, _Buffer, Qs) ->
+decode_query_section(<<>>=Rest, N, _Buffer, _Mdns, Qs) ->
     {Rest,reverse(Qs),N =/= 0};
-decode_query_section(Rest, 0, _Buffer, Qs) ->
+decode_query_section(Rest, 0, _Buffer, _Mdns, Qs) ->
     {Rest,reverse(Qs),false};
-decode_query_section(Bin, N, Buffer, Qs) ->
+decode_query_section(Bin, N, Buffer, Mdns, Qs) ->
     ?MATCH_ELSE_DECODE_ERROR(
        decode_name(Bin, Buffer),
        {<<T:16,C:16,Rest/binary>>,Name},
        begin
-           {Class,UnicastResponse} = decode_class(C),
+           {Class,UnicastResponse} = decode_class(C, Mdns),
            DnsQuery =
                #dns_query{
                   domain           = Name,
                   type             = decode_type(T),
                   class            = Class,
                   unicast_response = UnicastResponse},
-           decode_query_section(Rest, N-1, Buffer, [DnsQuery|Qs])
+           decode_query_section(Rest, N-1, Buffer, Mdns, [DnsQuery|Qs])
        end).
 
-decode_rr_section(Bin, N, Buffer) ->
-    decode_rr_section(Bin, N, Buffer, []).
-
-decode_rr_section(<<>>=Rest, N, _Buffer, RRs) ->
+decode_rr_section(Bin, N, Buffer, Opts) ->
+    decode_rr_section(Bin, N, Buffer, Opts, []).
+%%
+decode_rr_section(<<>>=Rest, N, _Buffer, _Opts, RRs) ->
     {Rest,reverse(RRs),N =/= 0};
-decode_rr_section(Rest, 0, _Buffer, RRs) ->
+decode_rr_section(Rest, 0, _Buffer, _Opts, RRs) ->
     {Rest,reverse(RRs),false};
-decode_rr_section(Bin, N, Buffer, RRs) ->
+decode_rr_section(Bin, N, Buffer, {Opcode,Mdns} = Opts, RRs) ->
     ?MATCH_ELSE_DECODE_ERROR(
        decode_name(Bin, Buffer),
        {<<T:16/unsigned,C:16/unsigned,TTL:4/binary,
@@ -215,7 +231,11 @@ decode_rr_section(Bin, N, Buffer, RRs) ->
            RR =
                case Type of
                    ?S_OPT ->
-                       <<ExtRcode,Version,Z:16>> = TTL,
+                       %% RFC 6891: 6.1.1. FORMERR if more than one dns_rr_opt
+                       lists:keymember(dns_rr_opt, 1, RRs) andalso
+                        throw(?DECODE_ERROR),
+                       <<ExtRcode,Version,DO:1,Z:15>> = TTL,
+                       DnssecOk = (DO =/= 0),
                        #dns_rr_opt{
                           domain           = Name,
                           type             = Type,
@@ -223,10 +243,33 @@ decode_rr_section(Bin, N, Buffer, RRs) ->
                           ext_rcode        = ExtRcode,
                           version          = Version,
                           z                = Z,
-                          data             = D};
+                          data             = D,
+                          do               = DnssecOk};
+                   ?S_TSIG ->
+                       %% RFC 8945: 5.2. FORMERR if not last
+                       %% RFC 8945: 5.2. FORMERR if more than one dns_rr_tsig
+                       %%                        (...covered by being last)
+                       Rest =/= <<>> andalso throw(?DECODE_ERROR),
+                       {DR,AlgName} = decode_name(D, Buffer),
+                       ?MATCH_ELSE_DECODE_ERROR(
+                          DR,
+                          <<Now:48, Fudge:16, MACSize:16, MAC:MACSize/binary,
+                            OriginalId:16, Error:16,
+                            OtherLen:16, OtherData:OtherLen/binary>>,
+                          #dns_rr_tsig{
+                             domain        = Name,
+                             type          = Type,
+                             offset        = byte_size(Buffer) - byte_size(Bin),
+                             algname       = AlgName,
+                             now           = Now,
+                             fudge         = Fudge,
+                             mac           = MAC,
+                             original_id   = OriginalId,
+                             error         = Error,
+                             other_data    = OtherData});
                    _ ->
-                       {Class,CacheFlush} = decode_class(C),
-                       Data = decode_data(D, Class, Type, Buffer),
+                       {Class,CacheFlush} = decode_class(C, Mdns),
+                       Data = decode_data(D, Class, Type, Buffer, Opcode),
                        <<TimeToLive:32/signed>> = TTL,
                        #dns_rr{
                           domain = Name,
@@ -236,24 +279,31 @@ decode_rr_section(Bin, N, Buffer, RRs) ->
                           data   = Data,
                           func   = CacheFlush}
                end,
-           decode_rr_section(Rest, N-1, Buffer, [RR|RRs])
+           decode_rr_section(Rest, N-1, Buffer, Opts, [RR|RRs])
        end).
 
 %%
 %% Encode a user query
 %%
 
-encode(Q) ->
-    QdCount = length(Q#dns_rec.qdlist),
-    AnCount = length(Q#dns_rec.anlist),
-    NsCount = length(Q#dns_rec.nslist),
-    ArCount = length(Q#dns_rec.arlist),
-    B0 = encode_header(Q#dns_rec.header, QdCount, AnCount, NsCount, ArCount),
+encode(Q) -> encode(Q, true). % Backwards compatible
+%%
+encode(
+  #dns_rec{
+     header = Header,
+     qdlist = QdList, anlist = AnList, nslist = NsList, arlist = ArList },
+  Mdns)
+  when is_boolean(Mdns) ->
+    B0 =
+        encode_header(
+          Header,
+          length(QdList), length(AnList), length(NsList), length(ArList)),
+    Opcode = Header#dns_header.opcode,
     C0 = gb_trees:empty(),
-    {B1,C1} = encode_query_section(B0, C0, Q#dns_rec.qdlist),
-    {B2,C2} = encode_res_section(B1, C1, Q#dns_rec.anlist),
-    {B3,C3} = encode_res_section(B2, C2, Q#dns_rec.nslist),
-    {B,_} = encode_res_section(B3, C3, Q#dns_rec.arlist),
+    {B1,C1} = encode_query_section(B0, Mdns, C0, QdList),
+    {B2,C2} = encode_res_section(B1, {Opcode,Mdns}, C1, AnList),
+    {B3,C3} = encode_res_section(B2, {Opcode,Mdns}, C2, NsList),
+    {B,_} = encode_res_section(B3, {Opcode,Mdns}, C3, ArList),
     B.
 
 
@@ -275,19 +325,20 @@ encode_header(#dns_header{id=Id}=H, QdCount, AnCount, NsCount, ArCount) ->
 
 %% RFC 1035: 4.1.2. Question section format
 %%
-encode_query_section(Bin, Comp, []) -> {Bin,Comp};
-encode_query_section(Bin0, Comp0, [#dns_query{domain=DName}=Q | Qs]) ->
+encode_query_section(Bin, _Mdns, Comp, []) -> {Bin,Comp};
+encode_query_section(Bin0, Mdns, Comp0, [#dns_query{domain=DName}=Q | Qs]) ->
     T = encode_type(Q#dns_query.type),
-    C = encode_class(Q#dns_query.class, Q#dns_query.unicast_response),
+    C = encode_class(
+          Q#dns_query.class, Mdns andalso Q#dns_query.unicast_response),
     {Bin,Comp} = encode_name(Bin0, Comp0, byte_size(Bin0), DName),
-    encode_query_section(<<Bin/binary,T:16,C:16>>, Comp, Qs).
+    encode_query_section(<<Bin/binary,T:16,C:16>>, Mdns, Comp, Qs).
 
 %% RFC 1035: 4.1.3. Resource record format
-%% RFC 2671: 4.3, 4.4, 4.6 OPT RR format
+%% RFC 6891:  6.1.2, 6.1.3, 6.2.3  Opt RR format
 %%
-encode_res_section(Bin, Comp, []) -> {Bin,Comp};
+encode_res_section(Bin, _Opts, Comp, []) -> {Bin,Comp};
 encode_res_section(
-  Bin, Comp,
+  Bin, Opts, Comp,
   [#dns_rr{
       domain = DName,
       type   = Type,
@@ -296,32 +347,50 @@ encode_res_section(
       ttl    = TTL,
       data   = Data} | Rs]) ->
     encode_res_section_rr(
-      Bin, Comp, Rs, DName, Type, Class, CacheFlush,
+      Bin, Opts, Comp, Rs, DName, Type, Class, CacheFlush,
       <<TTL:32/signed>>, Data);
 encode_res_section(
-  Bin, Comp,
+  Bin, Opts, Comp,
   [#dns_rr_opt{
       domain           = DName,
       udp_payload_size = UdpPayloadSize,
       ext_rcode        = ExtRCode,
       version          = Version,
       z                = Z,
-      data             = Data} | Rs]) ->
+      data             = Data,
+      do               = DnssecOk} | Rs]) ->
+    DO = case DnssecOk of true -> 1; false -> 0 end,
     encode_res_section_rr(
-      Bin, Comp, Rs, DName, ?S_OPT, UdpPayloadSize, false,
-      <<ExtRCode,Version,Z:16>>, Data).
+      Bin, Opts, Comp, Rs, DName, ?S_OPT, UdpPayloadSize, false,
+      <<ExtRCode,Version,DO:1,Z:15>>, Data);
+encode_res_section(
+  Bin, Opts, Comp,
+  [#dns_rr_tsig{
+      domain           = DName,
+      algname          = AlgName,
+      now              = Now,
+      fudge            = Fudge,
+      mac              = MAC,
+      original_id      = OriginalId,
+      error            = Error,
+      other_data       = OtherData}]) ->
+    Data = {AlgName,Now,Fudge,MAC,OriginalId,Error,OtherData},
+    encode_res_section_rr(
+      Bin, Opts, Comp, [], DName, ?S_TSIG, ?S_ANY, false,
+      <<0:32/signed>>, Data).
 
 encode_res_section_rr(
-  Bin0, Comp0, Rs, DName, Type, Class, CacheFlush, TTL, Data) ->
+  Bin0, {Opcode,Mdns} = Opts, Comp0, Rs,
+  DName, Type, Class, CacheFlush, TTL, Data) ->
     T = encode_type(Type),
-    C = encode_class(Class, CacheFlush),
+    C = encode_class(Class, Mdns and CacheFlush),
     {Bin,Comp1} = encode_name(Bin0, Comp0, byte_size(Bin0), DName),
     Pos = byte_size(Bin)+2+2+byte_size(TTL)+2,
-    {DataBin,Comp} = encode_data(Comp1, Pos, Type, Class, Data),
+    {DataBin,Comp} = encode_data(Comp1, Pos, Type, Class, Data, Opcode),
     DataSize = byte_size(DataBin),
     encode_res_section(
       <<Bin/binary,T:16,C:16,TTL/binary,DataSize:16,DataBin/binary>>,
-      Comp, Rs).
+      Opts, Comp, Rs).
 
 %%
 %% Resource types
@@ -345,6 +414,7 @@ decode_type(Type) ->
 	?T_MX -> ?S_MX;
 	?T_TXT -> ?S_TXT;
 	?T_AAAA -> ?S_AAAA;
+	?T_LOC -> ?S_LOC;
 	?T_SRV -> ?S_SRV;
 	?T_NAPTR -> ?S_NAPTR;
 	?T_OPT -> ?S_OPT;
@@ -354,7 +424,8 @@ decode_type(Type) ->
 	?T_UID -> ?S_UID;
 	?T_GID -> ?S_GID;
 	?T_UNSPEC -> ?S_UNSPEC;
-	%% Query type values which do not appear in resource records
+	?T_TSIG -> ?S_TSIG;
+	?T_IXFR -> ?S_IXFR;
 	?T_AXFR -> ?S_AXFR;
 	?T_MAILB -> ?S_MAILB;
 	?T_MAILA -> ?S_MAILA;
@@ -386,6 +457,7 @@ encode_type(Type) ->
 	?S_MX -> ?T_MX;
 	?S_TXT -> ?T_TXT;
 	?S_AAAA -> ?T_AAAA;
+	?S_LOC -> ?T_LOC;
 	?S_SRV -> ?T_SRV;
 	?S_NAPTR -> ?T_NAPTR;
 	?S_OPT -> ?T_OPT;
@@ -395,7 +467,8 @@ encode_type(Type) ->
 	?S_UID -> ?T_UID;
 	?S_GID -> ?T_GID;
 	?S_UNSPEC -> ?T_UNSPEC;
-	%% Query type values which do not appear in resource records
+	?S_TSIG -> ?T_TSIG;
+	?S_IXFR -> ?T_IXFR;
 	?S_AXFR -> ?T_AXFR;
 	?S_MAILB -> ?T_MAILB;
 	?S_MAILA -> ?T_MAILA;
@@ -410,19 +483,24 @@ encode_type(Type) ->
 %% Resource classes
 %%
 
-decode_class(C0) ->
+decode_class(C, false) ->
+    {decode_class(C),false};
+decode_class(C0, true) ->
     FlagBit = 16#8000,
     C = C0 band (bnot FlagBit),
-    Class =
+    Class = decode_class(C),
+    Flag = (C0 band FlagBit) =/= 0,
+    {Class,Flag}.
+
+decode_class(C) ->
         case C of
             ?C_IN    -> in;
             ?C_CHAOS -> chaos;
             ?C_HS    -> hs;
+        ?C_NONE  -> none;
             ?C_ANY   -> any;
             _ -> C    %% raw unknown class
-        end,
-    Flag = (C0 band FlagBit) =/= 0,
-    {Class,Flag}.
+    end.
 
 
 encode_class(Class, Flag) ->
@@ -437,6 +515,7 @@ encode_class(Class) ->
 	in    -> ?C_IN;
 	chaos -> ?C_CHAOS;
 	hs    -> ?C_HS;
+	none  -> ?C_NONE;
 	any   -> ?C_ANY;
 	Class when is_integer(Class) -> Class    %% raw unknown class
     end.
@@ -446,6 +525,8 @@ decode_opcode(Opcode) ->
 	?QUERY -> 'query';
 	?IQUERY -> iquery;
 	?STATUS -> status;
+	?NOTIFY -> notify;
+	?UPDATE -> update;
 	_ when is_integer(Opcode) -> Opcode %% non-standard opcode
     end.
 
@@ -454,6 +535,8 @@ encode_opcode(Opcode) ->
 	'query' -> ?QUERY;
 	iquery -> ?IQUERY;
 	status -> ?STATUS;
+	notify -> ?NOTIFY;
+	update -> ?UPDATE;
 	_ when is_integer(Opcode) -> Opcode %% non-standard opcode
     end.
 
@@ -465,7 +548,14 @@ encode_boolean(B) when is_integer(B) -> B.
 decode_boolean(0) -> false;
 decode_boolean(I) when is_integer(I) -> true.
 
-
+decode_data(Data, Class, Type, Buffer, Opcode) ->
+    if
+        %% RFC 2136: 2.4. Allow length zero data for UPDATE
+        Opcode == ?UPDATE, Data == <<>> ->
+            #dns_rr{}#dns_rr.data;
+        true ->
+            decode_data(Data, Class, Type, Buffer)
+    end.
 %%
 %% Data field -> term() content representation
 %%
@@ -524,6 +614,21 @@ decode_data(Data, ?S_MX, Buffer) ->
        Data,
        <<Prio:16,Dom/binary>>,
        {Prio,decode_domain(Dom, Buffer)});
+decode_data(Data, ?S_LOC, _) ->
+    ?MATCH_ELSE_DECODE_ERROR(
+       Data,
+       <<Version:8, SizeBase:4, SizeExp:4,
+         HorizPreBase:4, HorizPreExp:4, VertPreBase:4, VertPreExp:4,
+         Latitude:32, Longitude:32, Altitude:32>>,
+       ((Version =:= 0) andalso
+        ?is_decimal(SizeBase) andalso ?is_decimal(SizeExp) andalso
+        ?is_decimal(HorizPreBase) andalso ?is_decimal(HorizPreExp) andalso
+        ?is_decimal(VertPreBase) andalso ?is_decimal(VertPreExp)),
+       {{decode_loc_angle(Latitude), decode_loc_angle(Longitude)},
+        decode_loc_altitude(Altitude),
+        decode_loc_size(SizeBase, SizeExp),
+        {decode_loc_size(HorizPreBase, HorizPreExp),
+         decode_loc_size(VertPreBase, VertPreExp)}});
 decode_data(Data, ?S_SRV, Buffer) ->
     ?MATCH_ELSE_DECODE_ERROR(
        Data,
@@ -663,20 +768,16 @@ decode_name_label(Label, Name, N) ->
 	    erlang:error(badarg, [Label,Name,N])
     end.
 
+encode_data(Comp, Pos, Type, Class, Data, Opcode) ->
+    if
+        Opcode == update, Data == #dns_rr{}#dns_rr.data ->
+            {<<>>,Comp};
+        true ->
+            encode_data(Comp, Pos, Type, Class, Data)
+    end.
 %%
 %% Data field -> {binary(),NewCompressionTable}
 %%
-%% Class IN RRs
-encode_data(Comp, _, ?S_A, in, Addr) ->
-    {A,B,C,D} = Addr,
-    {<<A,B,C,D>>,Comp};
-encode_data(Comp, _, ?S_AAAA, in, Addr) ->
-    {A,B,C,D,E,F,G,H} = Addr,
-    {<<A:16,B:16,C:16,D:16,E:16,F:16,G:16,H:16>>,Comp};
-encode_data(Comp, _, ?S_WKS, in, Data) ->
-    {{A,B,C,D},Proto,BitMap} = Data,
-    BitMapBin = iolist_to_binary(BitMap),
-    {<<A,B,C,D,Proto,BitMapBin/binary>>,Comp};
 %% OPT pseudo-RR (of no class) - should not take this way;
 %% this must be a #dns_rr{type = ?S_OPT} instead of a #dns_rr_opt{},
 %% so good luck getting in particular Class and TTL right...
@@ -693,6 +794,16 @@ encode_data(Comp, Pos, Type, Class, Data) ->
 %%
 %%
 %% Standard RRs (any class)
+encode_data(Comp, _, ?S_A, Addr) ->
+    {A,B,C,D} = Addr,
+    {<<A,B,C,D>>,Comp};
+encode_data(Comp, _, ?S_AAAA, Addr) ->
+    {A,B,C,D,E,F,G,H} = Addr,
+    {<<A:16,B:16,C:16,D:16,E:16,F:16,G:16,H:16>>,Comp};
+encode_data(Comp, _, ?S_WKS, Data) ->
+    {{A,B,C,D},Proto,BitMap} = Data,
+    BitMapBin = iolist_to_binary(BitMap),
+    {<<A,B,C,D,Proto,BitMapBin/binary>>,Comp};
 encode_data(Comp, Pos, ?S_SOA, Data) ->
     {MName,RName,Serial,Refresh,Retry,Expiry,Minimum} = Data,
     {B1,Comp1} = encode_name(Comp, Pos, MName),
@@ -720,6 +831,25 @@ encode_data(Comp, Pos, ?S_MINFO, Data) ->
 encode_data(Comp, Pos, ?S_MX, Data) ->
     {Pref,Exch} = Data,
     encode_name(<<Pref:16>>, Comp, Pos+2, Exch);
+encode_data(Comp, _, ?S_LOC, Data) ->
+    %% Similar to the Master File Format in section 3 of RFC 1876
+    case Data of
+        {{Latitude, Longitude}, Altitude, Size, {HorizPre, VertPre}} ->
+            ok;
+        {{Latitude, Longitude}, Altitude, Size} ->
+            HorizPre = 10_000_00, VertPre = 10_00,
+            ok;
+        {{Latitude, Longitude}, Altitude} ->
+            Size = 1_00, HorizPre = 10_000_00, VertPre = 10_00,
+            ok
+    end,
+    Version = 0,
+    {<<Version:8, (encode_loc_size(Size))/binary,
+       (encode_loc_size(HorizPre))/binary, (encode_loc_size(VertPre))/binary,
+       (encode_loc_angle(Latitude)):32,
+       (encode_loc_angle(Longitude)):32,
+       (encode_loc_altitude(Altitude)):32>>,
+     Comp};
 encode_data(Comp, Pos, ?S_SRV, Data) ->
     {Prio,Weight,Port,Target} = Data,
     encode_name(<<Prio:16,Weight:16,Port:16>>, Comp, Pos+2+2+2, Target);
@@ -748,6 +878,17 @@ encode_data(Comp, _, ?S_CAA, Data)->
         _ ->
             {encode_txt(Data),Comp}
     end;
+encode_data(Comp, _, ?S_TSIG, Data)->
+    {AlgName,Now,Fudge,MAC,OriginalId,Error,OtherData} = Data,
+    %% Bypass name compression (RFC 8945, section 4.2)
+    {AlgNameEncoded,_} = encode_name(gb_trees:empty(), 0, AlgName),
+    MACSize = byte_size(MAC),
+    OtherLen = byte_size(OtherData),
+    DataB = <<AlgNameEncoded/binary,
+	     Now:48, Fudge:16, MACSize:16, MAC:MACSize/binary,
+	     OriginalId:16, Error:16,
+	     OtherLen:16, OtherData:OtherLen/binary>>,
+    {DataB,Comp};
 %%
 %% sofar unknown or non standard
 encode_data(Comp, _Pos, Type, Data) when is_integer(Type) ->
@@ -796,7 +937,7 @@ encode_name(Comp, Pos, Name) ->
 %% only compression that suffers. Furthermore encode+decode
 %% this way becomes an identity operation for any decoded
 %% DNS message which is nice for testing encode.
-%%
+%% 
 encode_name(Bin0, Comp0, Pos, Name) ->
     case encode_labels(Bin0, Comp0, Pos, name2labels(Name)) of
 	{Bin,_}=Result when byte_size(Bin) - byte_size(Bin0) =< 255 -> Result;
@@ -838,4 +979,84 @@ encode_labels(Bin, Comp0, Pos, [L|Ls]=Labels)
 	{value,Ptr} ->
 	    %% Name compression - point to already encoded name
 	    {<<Bin/binary,3:2,Ptr:14>>,Comp0}
+    end.
+
+
+decode_loc_angle(X) ->
+    (X - 16#8000_0000) / 3600_000.
+
+encode_loc_angle(X) when is_float(X) ->
+    %% Degrees (1/360 of a turn)
+    encode_loc_angle(round(X * 3600_000));
+encode_loc_angle(X)
+  when is_integer(X), -16#8000_0000 =< X, X =< 16#7FFF_FFFF ->
+    %% 1/1000:s of arc second
+    X + 16#8000_0000.  % Zero is encoded as 2^31
+
+
+decode_loc_altitude(X) ->
+    (X - 100_000_00) / 100.
+
+encode_loc_altitude(X) when is_float(X) ->
+    %% Meters
+    encode_loc_altitude(round(X * 100));
+encode_loc_altitude(X)
+  when is_integer(X), -100_000_00 =< X, X =< 16#FFFF_FFFF - 100_000_00 ->
+    %% Centimeters above a base level 100_000 m below
+    %% the GPS reference spheroid [DoD WGS-1984]
+    X + 100_000_00.
+
+
+decode_loc_size(Base, Exponent) ->
+    round(Base * math:pow(10, Exponent)) / 100.
+
+%% Return the smallest encoded value >= X;
+%% a bit like ceil(X) of encoded values
+%%
+encode_loc_size(X) when is_float(X) ->
+    %% Meters
+    encode_loc_size(round(X * 100));
+encode_loc_size(0) ->
+    0;
+encode_loc_size(X)
+  when is_integer(X), 0 =< X, X =< 9000_000_000 ->
+    %% Centimeters, to be encoded as Digit * 10^Exponent
+    %% with both Digit and Exponent in 0..9,
+    %% limiting the range to 0..9e9
+    %%
+    Exponent = floor(math:log10((X - 0.05) / 0.9)),
+    Multiplier = round(math:pow(10, Exponent)),
+    Base = (X + Multiplier - 1) div Multiplier,
+    <<Base:4, Exponent:4>>.
+
+decode_algname(AlgName) ->
+    case AlgName of
+        ?T_TSIG_HMAC_MD5 -> ?S_TSIG_HMAC_MD5;
+        ?T_TSIG_GSS_TSIG -> ?S_TSIG_GSS_TSIG;
+        ?T_TSIG_HMAC_SHA1 -> ?S_TSIG_HMAC_SHA1;
+        ?T_TSIG_HMAC_SHA1_96 -> ?S_TSIG_HMAC_SHA1_96;
+        ?T_TSIG_HMAC_SHA224 -> ?S_TSIG_HMAC_SHA224;
+        ?T_TSIG_HMAC_SHA256 -> ?S_TSIG_HMAC_SHA256;
+        ?T_TSIG_HMAC_SHA256_128 -> ?S_TSIG_HMAC_SHA256_128;
+        ?T_TSIG_HMAC_SHA384 -> ?S_TSIG_HMAC_SHA384;
+        ?T_TSIG_HMAC_SHA384_192 -> ?S_TSIG_HMAC_SHA384_192;
+        ?T_TSIG_HMAC_SHA512 -> ?S_TSIG_HMAC_SHA512;
+        ?T_TSIG_HMAC_SHA512_256 -> ?S_TSIG_HMAC_SHA512_256;
+       _ -> AlgName  % raw unknown algname
+    end.
+
+encode_algname(Alg) ->
+    case Alg of
+        ?S_TSIG_HMAC_MD5 -> ?T_TSIG_HMAC_MD5;
+        ?S_TSIG_GSS_TSIG -> ?T_TSIG_GSS_TSIG;
+        ?S_TSIG_HMAC_SHA1 -> ?T_TSIG_HMAC_SHA1;
+        ?S_TSIG_HMAC_SHA1_96 -> ?T_TSIG_HMAC_SHA1_96;
+        ?S_TSIG_HMAC_SHA224 -> ?T_TSIG_HMAC_SHA224;
+        ?S_TSIG_HMAC_SHA256 -> ?T_TSIG_HMAC_SHA256;
+        ?S_TSIG_HMAC_SHA256_128 -> ?T_TSIG_HMAC_SHA256_128;
+        ?S_TSIG_HMAC_SHA384 -> ?T_TSIG_HMAC_SHA384;
+        ?S_TSIG_HMAC_SHA384_192 -> ?T_TSIG_HMAC_SHA384_192;
+        ?S_TSIG_HMAC_SHA512 -> ?T_TSIG_HMAC_SHA512;
+        ?S_TSIG_HMAC_SHA512_256 -> ?T_TSIG_HMAC_SHA512_256;
+       Alg when is_list(Alg) -> Alg  % raw unknown algname
     end.

--- a/src/mdns_lite_inet_dns.hrl
+++ b/src/mdns_lite_inet_dns.hrl
@@ -1,4 +1,4 @@
-%% SPDX-FileCopyrightText: Ericsson AB 1997-2021. All Rights Reserved.
+%% SPDX-FileCopyrightText: Ericsson AB 1997-2025. All Rights Reserved.
 %%
 %% SPDX-License-Identifier: Apache-2.0
 %%
@@ -9,19 +9,10 @@
 %% Currently defined opcodes
 %%
 -define(QUERY,    16#0).          %% standard query
--define(IQUERY,   16#1).	      %% inverse query 
--define(STATUS,   16#2).	      %% nameserver status query 
-%% -define(xxx,   16#3)  %% 16#3 reserved
-%%  non standard
--define(UPDATEA,  16#9).	       %% add resource record
--define(UPDATED,  16#a).	       %% delete a specific resource record
--define(UPDATEDA, 16#b).	       %% delete all nemed resource record
--define(UPDATEM,  16#c).	       %% modify a specific resource record
--define(UPDATEMA, 16#d).	       %% modify all named resource record
-
--define(ZONEINIT, 16#e).	       %% initial zone transfer 
--define(ZONEREF,  16#f).	       %% incremental zone referesh
-
+-define(IQUERY,   16#1).	%% inverse query
+-define(STATUS,   16#2).	%% nameserver status query
+-define(NOTIFY,   16#4).	%% notify
+-define(UPDATE,   16#5).	%% dynamic update
 
 %%
 %% Currently defined response codes
@@ -32,9 +23,16 @@
 -define(NXDOMAIN, 3).		%% non existent domain
 -define(NOTIMP,	  4).		%% not implemented
 -define(REFUSED,  5).		%% query refused
-%%	non standard 
--define(NOCHANGE, 16#f).		%% update failed to change db
--define(BADVERS,  16).
+-define(YXDOMAIN, 6).		%% name exists when it should not (DDNS)
+-define(YXRRSET,  7).		%% RR set exists when it should not (DDNS)
+-define(NXRRSET,  8).		%% RR set that should exist does not (DDNS)
+-define(NOTAUTH,  9).		%% server not authoritative for zone (DDNS)
+-define(NOTZONE,  10).		%% name not contained in zone (DDNS)
+-define(BADVERS,  16).		%% bad version EDNS pseudo-rr RFC6891: 6.1.3
+-define(BADSIG,   16).		%% TSIG Signature Failure (TSIG)
+-define(BADKEY,   17).		%% Key not recognized (TSIG)
+-define(BADTIME,  18).		%% Signature out of time window (TSIG)
+-define(BADTRUNC, 22).		%% Bad Truncation (TSIG)
 
 %%
 %% Type values for resources and queries
@@ -56,11 +54,13 @@
 -define(T_MX,		15).		%% mail routing information
 -define(T_TXT,		16).		%% text strings
 -define(T_AAAA,         28).            %% ipv6 address
+%% LOC (RFC 1876)
+-define(T_LOC,          29).            %% location information
 %% SRV (RFC 2052)
 -define(T_SRV,          33).            %% services
 %% NAPTR (RFC 2915)
 -define(T_NAPTR,        35).            %% naming authority pointer
--define(T_OPT,          41).            %% EDNS pseudo-rr RFC2671(7)
+-define(T_OPT,          41).            %% EDNS pseudo-rr RFC6891(7)
 %% SPF (RFC 4408)
 -define(T_SPF,          99).            %% server policy framework
 %%      non standard
@@ -68,8 +68,9 @@
 -define(T_UID,		101).		%% user ID
 -define(T_GID,		102).		%% group ID
 -define(T_UNSPEC,	103).		%% Unspecified format (binary data)
-%%	Query type values which do not appear in resource records
--define(T_AXFR,		252).		%% transfer zone of authority
+-define(T_TSIG,		250).		%% transaction signature
+-define(T_IXFR,		251).		%% incremental zone transfer
+-define(T_AXFR,		252).		%% zone transfer
 -define(T_MAILB,	253).		%% transfer mailbox records
 -define(T_MAILA,	254).		%% transfer mail agent records
 -define(T_ANY,		255).		%% wildcard match
@@ -98,11 +99,13 @@
 -define(S_MX,		mx).		%% mail routing information
 -define(S_TXT,		txt).		%% text strings
 -define(S_AAAA,         aaaa).          %% ipv6 address
+%% LOC (RFC 1876)
+-define(S_LOC,          loc).           %% location information
 %% SRV (RFC 2052)
 -define(S_SRV,          srv).           %% services
 %% NAPTR (RFC 2915)
 -define(S_NAPTR,        naptr).         %% naming authority pointer
--define(S_OPT,          opt).           %% EDNS pseudo-rr RFC2671(7)
+-define(S_OPT,          opt).           %% EDNS pseudo-rr RFC6891(7)
 %% SPF (RFC 4408)
 -define(S_SPF,          spf).           %% server policy framework
 %%      non standard
@@ -110,8 +113,9 @@
 -define(S_UID,		uid).		%% user ID
 -define(S_GID,		gid).		%% group ID
 -define(S_UNSPEC,	unspec).        %% Unspecified format (binary data)
-%%	Query type values which do not appear in resource records
--define(S_AXFR,		axfr).		%% transfer zone of authority
+-define(S_TSIG,		tsig).		%% transaction signature
+-define(S_IXFR,		ixfr).		%% incremental zone transfer
+-define(S_AXFR,		axfr).		%% zone transfer
 -define(S_MAILB,	mailb).		%% transfer mailbox records
 -define(S_MAILA,	maila).		%% transfer mail agent records
 -define(S_ANY,		any).		%% wildcard match
@@ -123,32 +127,54 @@
 %%
 %% Values for class field
 %%
-
 -define(C_IN,		1).      	%% the arpa internet
 -define(C_CHAOS,	3).		%% for chaos net at MIT
 -define(C_HS,		4).		%% for Hesiod name server at MIT
-%%  Query class values which do not appear in resource records
--define(C_ANY,		255).		%% wildcard match 
+-define(C_NONE,		254).		%% for DDNS (RFC2136, section 2.4)
+-define(C_ANY,		255).		%% wildcard match
 
-
-%% indirection mask for compressed domain names
--define(INDIR_MASK, 16#c0).
+%%
+%% TSIG Algorithms and Identifiers (RFC8945, section 6)
+%%
+-define(T_TSIG_HMAC_MD5,		"HMAC-MD5.SIG-ALG.REG.INT").
+-define(T_TSIG_GSS_TSIG,		"gss-tsig").
+-define(T_TSIG_HMAC_SHA1,		"hmac-sha1").
+-define(T_TSIG_HMAC_SHA1_96,		"hmac-sha1_96").
+-define(T_TSIG_HMAC_SHA224,		"hmac-sha224").
+-define(T_TSIG_HMAC_SHA256,		"hmac-sha256").
+-define(T_TSIG_HMAC_SHA256_128,		"hmac-sha256-128").
+-define(T_TSIG_HMAC_SHA384,		"hmac-sha384").
+-define(T_TSIG_HMAC_SHA384_192,		"hmac-sha384-192").
+-define(T_TSIG_HMAC_SHA512,		"hmac-sha512").
+-define(T_TSIG_HMAC_SHA512_256,		"hmac-sha512-256").
+% map mostly to crypto:hmac_hash_algorithm()
+-define(S_TSIG_HMAC_MD5,		md5).
+-define(S_TSIG_GSS_TSIG,		gss_tsig).
+-define(S_TSIG_HMAC_SHA1,		sha).
+-define(S_TSIG_HMAC_SHA1_96,		{sha,96}).
+-define(S_TSIG_HMAC_SHA224,		sha224).
+-define(S_TSIG_HMAC_SHA256,		sha256).
+-define(S_TSIG_HMAC_SHA256_128,		{sha256,128}).
+-define(S_TSIG_HMAC_SHA384,		sha384).
+-define(S_TSIG_HMAC_SHA384_192,		{sha384,192}).
+-define(S_TSIG_HMAC_SHA512,		sha512).
+-define(S_TSIG_HMAC_SHA512_256,		{sha512,256}).
 
 %%
 %% Structure for query header, the order of the fields is machine and
 %% compiler dependent, in our case, the bits within a byte are assignd
-%% least significant first, while the order of transmition is most
+%% least significant first, while the order of transmission is most
 %% significant first.  This requires a somewhat confusing rearrangement.
 %%
--record(dns_header, 
+-record(dns_header,
 	{
-	 id = 0,       %% ushort query identification number 
+	 id = 0,       %% ushort query identification number
 	 %% byte F0
 	 qr = 0,       %% :1   response flag
 	 opcode = 0,   %% :4   purpose of message
-	 aa = 0,       %% :1   authoritive answer
+	 aa = 0,       %% :1   authoritative answer
 	 tc = 0,       %% :1   truncated message
-	 rd = 0,       %% :1   recursion desired 
+	 rd = 0,       %% :1   recursion desired
 	 %% byte F1
 	 ra = 0,       %% :1   recursion available
 	 pr = 0,       %% :1   primary server required (non standard)
@@ -159,9 +185,9 @@
 -record(dns_rec,
 	{
 	 header,       %% dns_header record
-	 qdlist = [],  %% list of question entries
-	 anlist = [],  %% list of answer entries
-	 nslist = [],  %% list of authority entries
+	 qdlist = [],  %% list of question (for UPDATE 'zone') entries
+	 anlist = [],  %% list of answer (for UPDATE 'prequisites') entries
+	 nslist = [],  %% list of authority (for UPDATE 'update') entries
 	 arlist = []   %% list of resource entries
 	}).
 
@@ -170,28 +196,46 @@
 	{
 	 domain = "",   %% resource domain
 	 type = any,    %% resource type
-	 class = in,    %% reource class
+	 class = in,    %% resource class
 	 cnt = 0,       %% access count
 	 ttl = 0,       %% time to live
 	 data = [],     %% raw data
 	  %%
 	 tm,            %% creation time
-         bm = [],       %% Bitmap storing domain character case information.
+         bm = "",       %% Used to be defined as:
+         %%                Bitmap storing domain character case information
+         %%       but now; Case normalized domain
          func = false   %% Was: Optional function calculating the data field.
          %%                Now: cache-flush Class flag from mDNS RFC 6762
 	}).
 
 -define(DNS_UDP_PAYLOAD_SIZE, 1280).
 
--record(dns_rr_opt,           %% EDNS RR OPT (RFC2671), dns_rr{type=opt}
+-record(dns_rr_opt,           %% EDNS RR OPT (RFC6891), dns_rr{type=opt}
 	{
 	  domain = "",        %% should be the root domain
 	  type = opt,
-	  udp_payload_size = ?DNS_UDP_PAYLOAD_SIZE, %% RFC2671(4.5 CLASS)
-	  ext_rcode = 0,      %% RFC2671(4.6 EXTENDED-RCODE)
-	  version = 0,        %% RFC2671(4.6 VERSION)
-	  z = 0,              %% RFC2671(4.6 Z)
-	  data = []           %% RFC2671(4.4)
+	  udp_payload_size = ?DNS_UDP_PAYLOAD_SIZE, %% RFC6891(6.2.3 CLASS)
+	  ext_rcode = 0,      %% RFC6891(6.1.3 EXTENDED-RCODE)
+	  version = 0,        %% RFC6891(6.1.3 VERSION)
+	  z = 0,              %% RFC6891(6.1.3 Z)
+	  data = [],          %% RFC6891(6.1.2 RDATA)
+          do = false          %% RFC6891(6.1.3 DO)
+	 }).
+
+-record(dns_rr_tsig,          %% TSIG RR OPT (RFC8945), dns_rr{type=tsig}
+	{
+	  domain = "",        %% name of the key
+	  type = tsig,
+	  offset,             %% position of RR in packet
+	  %% RFC8945(4.2 TSIG Record Format)
+	  algname,
+	  now,
+	  fudge,
+	  mac,
+	  original_id = #dns_header{}#dns_header.id,
+	  error = #dns_header{}#dns_header.rcode,
+	  other_data = <<>>
 	 }).
 
 -record(dns_query,

--- a/src/mdns_lite_inet_dns_record_adts.hrl
+++ b/src/mdns_lite_inet_dns_record_adts.hrl
@@ -11,8 +11,8 @@
 
 %% Split #dns_query{} into property list
 %%
-dns_query(#dns_query{domain=V1,type=V2,class=V3}) ->
-    [{domain,V1},{type,V2},{class,V3}].
+dns_query(#dns_query{domain=V1,type=V2,class=V3,unicast_response=V4}) ->
+    [{domain,V1},{type,V2},{class,V3},{unicast_response,V4}].
 
 %% Get one field value from #dns_query{}
 %%
@@ -22,6 +22,8 @@ dns_query(#dns_query{type=V2}, type) ->
     V2;
 dns_query(#dns_query{class=V3}, class) ->
     V3;
+dns_query(#dns_query{unicast_response=V4}, unicast_response) ->
+    V4;
 %% Map field name list to value list from #dns_query{}
 %%
 dns_query(#dns_query{}, []) ->
@@ -31,7 +33,9 @@ dns_query(#dns_query{domain=V1}=R, [domain|L]) ->
 dns_query(#dns_query{type=V2}=R, [type|L]) ->
     [V2|dns_query(R, L)];
 dns_query(#dns_query{class=V3}=R, [class|L]) ->
-    [V3|dns_query(R, L)].
+    [V3|dns_query(R, L)];
+dns_query(#dns_query{unicast_response=V4}=R, [unicast_response|L]) ->
+    [V4|dns_query(R, L)].
 
 %% Generate default #dns_query{}
 %%
@@ -51,19 +55,23 @@ make_dns_query(type, V2) ->
     #dns_query{type=V2};
 make_dns_query(class, V3) ->
     #dns_query{class=V3};
+make_dns_query(unicast_response, V4) ->
+    #dns_query{unicast_response=V4};
 %%
 %% Update #dns_query{} from property list
 %%
-make_dns_query(#dns_query{domain=V1,type=V2,class=V3}, L) when is_list(L) ->
-    do_make_dns_query(L, V1,V2,V3).
-do_make_dns_query([], V1,V2,V3) ->
-    #dns_query{domain=V1,type=V2,class=V3};
-do_make_dns_query([{domain,V1}|L], _,V2,V3) ->
-    do_make_dns_query(L, V1,V2,V3);
-do_make_dns_query([{type,V2}|L], V1,_,V3) ->
-    do_make_dns_query(L, V1,V2,V3);
-do_make_dns_query([{class,V3}|L], V1,V2,_) ->
-    do_make_dns_query(L, V1,V2,V3).
+make_dns_query(#dns_query{domain=V1,type=V2,class=V3,unicast_response=V4}, L) when is_list(L) ->
+    do_make_dns_query(L, V1,V2,V3,V4).
+do_make_dns_query([], V1,V2,V3,V4) ->
+    #dns_query{domain=V1,type=V2,class=V3,unicast_response=V4};
+do_make_dns_query([{domain,V1}|L], _,V2,V3,V4) ->
+    do_make_dns_query(L, V1,V2,V3,V4);
+do_make_dns_query([{type,V2}|L], V1,_,V3,V4) ->
+    do_make_dns_query(L, V1,V2,V3,V4);
+do_make_dns_query([{class,V3}|L], V1,V2,_,V4) ->
+    do_make_dns_query(L, V1,V2,V3,V4);
+do_make_dns_query([{unicast_response,V4}|L], V1,V2,V3,_) ->
+    do_make_dns_query(L, V1,V2,V3,V4).
 
 %% Update one field of #dns_query{}
 %%
@@ -72,7 +80,9 @@ make_dns_query(#dns_query{}=R, domain, V1) ->
 make_dns_query(#dns_query{}=R, type, V2) ->
     R#dns_query{type=V2};
 make_dns_query(#dns_query{}=R, class, V3) ->
-    R#dns_query{class=V3}.
+    R#dns_query{class=V3};
+make_dns_query(#dns_query{}=R, unicast_response, V4) ->
+    R#dns_query{unicast_response=V4}.
 
 
 %%
@@ -83,8 +93,8 @@ make_dns_query(#dns_query{}=R, class, V3) ->
 
 %% Split #dns_rr{} into property list
 %%
-dns_rr(#dns_rr{domain=V1,type=V2,class=V3,ttl=V4,data=V5}) ->
-    [{domain,V1},{type,V2},{class,V3},{ttl,V4},{data,V5}].
+dns_rr(#dns_rr{domain=V1,type=V2,class=V3,ttl=V4,data=V5,func=V6}) ->
+    [{domain,V1},{type,V2},{class,V3},{ttl,V4},{data,V5},{func,V6}].
 
 %% Get one field value from #dns_rr{}
 %%
@@ -98,6 +108,8 @@ dns_rr(#dns_rr{ttl=V4}, ttl) ->
     V4;
 dns_rr(#dns_rr{data=V5}, data) ->
     V5;
+dns_rr(#dns_rr{func=V6}, func) ->
+    V6;
 %% Map field name list to value list from #dns_rr{}
 %%
 dns_rr(#dns_rr{}, []) ->
@@ -111,7 +123,9 @@ dns_rr(#dns_rr{class=V3}=R, [class|L]) ->
 dns_rr(#dns_rr{ttl=V4}=R, [ttl|L]) ->
     [V4|dns_rr(R, L)];
 dns_rr(#dns_rr{data=V5}=R, [data|L]) ->
-    [V5|dns_rr(R, L)].
+    [V5|dns_rr(R, L)];
+dns_rr(#dns_rr{func=V6}=R, [func|L]) ->
+    [V6|dns_rr(R, L)].
 
 %% Generate default #dns_rr{}
 %%
@@ -135,23 +149,27 @@ make_dns_rr(ttl, V4) ->
     #dns_rr{ttl=V4};
 make_dns_rr(data, V5) ->
     #dns_rr{data=V5};
+make_dns_rr(func, V6) ->
+    #dns_rr{func=V6};
 %%
 %% Update #dns_rr{} from property list
 %%
-make_dns_rr(#dns_rr{domain=V1,type=V2,class=V3,ttl=V4,data=V5}, L) when is_list(L) ->
-    do_make_dns_rr(L, V1,V2,V3,V4,V5).
-do_make_dns_rr([], V1,V2,V3,V4,V5) ->
-    #dns_rr{domain=V1,type=V2,class=V3,ttl=V4,data=V5};
-do_make_dns_rr([{domain,V1}|L], _,V2,V3,V4,V5) ->
-    do_make_dns_rr(L, V1,V2,V3,V4,V5);
-do_make_dns_rr([{type,V2}|L], V1,_,V3,V4,V5) ->
-    do_make_dns_rr(L, V1,V2,V3,V4,V5);
-do_make_dns_rr([{class,V3}|L], V1,V2,_,V4,V5) ->
-    do_make_dns_rr(L, V1,V2,V3,V4,V5);
-do_make_dns_rr([{ttl,V4}|L], V1,V2,V3,_,V5) ->
-    do_make_dns_rr(L, V1,V2,V3,V4,V5);
-do_make_dns_rr([{data,V5}|L], V1,V2,V3,V4,_) ->
-    do_make_dns_rr(L, V1,V2,V3,V4,V5).
+make_dns_rr(#dns_rr{domain=V1,type=V2,class=V3,ttl=V4,data=V5,func=V6}, L) when is_list(L) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5,V6).
+do_make_dns_rr([], V1,V2,V3,V4,V5,V6) ->
+    #dns_rr{domain=V1,type=V2,class=V3,ttl=V4,data=V5,func=V6};
+do_make_dns_rr([{domain,V1}|L], _,V2,V3,V4,V5,V6) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5,V6);
+do_make_dns_rr([{type,V2}|L], V1,_,V3,V4,V5,V6) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5,V6);
+do_make_dns_rr([{class,V3}|L], V1,V2,_,V4,V5,V6) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5,V6);
+do_make_dns_rr([{ttl,V4}|L], V1,V2,V3,_,V5,V6) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5,V6);
+do_make_dns_rr([{data,V5}|L], V1,V2,V3,V4,_,V6) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5,V6);
+do_make_dns_rr([{func,V6}|L], V1,V2,V3,V4,V5,_) ->
+    do_make_dns_rr(L, V1,V2,V3,V4,V5,V6).
 
 %% Update one field of #dns_rr{}
 %%
@@ -164,7 +182,9 @@ make_dns_rr(#dns_rr{}=R, class, V3) ->
 make_dns_rr(#dns_rr{}=R, ttl, V4) ->
     R#dns_rr{ttl=V4};
 make_dns_rr(#dns_rr{}=R, data, V5) ->
-    R#dns_rr{data=V5}.
+    R#dns_rr{data=V5};
+make_dns_rr(#dns_rr{}=R, func, V6) ->
+    R#dns_rr{func=V6}.
 
 
 %%
@@ -175,8 +195,8 @@ make_dns_rr(#dns_rr{}=R, data, V5) ->
 
 %% Split #dns_rr_opt{} into property list
 %%
-dns_rr_opt(#dns_rr_opt{domain=V1,type=V2,udp_payload_size=V3,ext_rcode=V4,version=V5,z=V6,data=V7}) ->
-    [{domain,V1},{type,V2},{udp_payload_size,V3},{ext_rcode,V4},{version,V5},{z,V6},{data,V7}].
+dns_rr_opt(#dns_rr_opt{domain=V1,type=V2,udp_payload_size=V3,ext_rcode=V4,version=V5,z=V6,data=V7,do=V8}) ->
+    [{domain,V1},{type,V2},{udp_payload_size,V3},{ext_rcode,V4},{version,V5},{z,V6},{data,V7},{do,V8}].
 
 %% Get one field value from #dns_rr_opt{}
 %%
@@ -194,6 +214,8 @@ dns_rr_opt(#dns_rr_opt{z=V6}, z) ->
     V6;
 dns_rr_opt(#dns_rr_opt{data=V7}, data) ->
     V7;
+dns_rr_opt(#dns_rr_opt{do=V8}, do) ->
+    V8;
 %% Map field name list to value list from #dns_rr_opt{}
 %%
 dns_rr_opt(#dns_rr_opt{}, []) ->
@@ -211,7 +233,9 @@ dns_rr_opt(#dns_rr_opt{version=V5}=R, [version|L]) ->
 dns_rr_opt(#dns_rr_opt{z=V6}=R, [z|L]) ->
     [V6|dns_rr_opt(R, L)];
 dns_rr_opt(#dns_rr_opt{data=V7}=R, [data|L]) ->
-    [V7|dns_rr_opt(R, L)].
+    [V7|dns_rr_opt(R, L)];
+dns_rr_opt(#dns_rr_opt{do=V8}=R, [do|L]) ->
+    [V8|dns_rr_opt(R, L)].
 
 %% Generate default #dns_rr_opt{}
 %%
@@ -226,24 +250,26 @@ make_dns_rr_opt(L) when is_list(L) ->
 %%
 %% Update #dns_rr_opt{} from property list
 %%
-make_dns_rr_opt(#dns_rr_opt{domain=V1,type=V2,udp_payload_size=V3,ext_rcode=V4,version=V5,z=V6,data=V7}, L) when is_list(L) ->
-    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7).
-do_make_dns_rr_opt([], V1,V2,V3,V4,V5,V6,V7) ->
-    #dns_rr_opt{domain=V1,type=V2,udp_payload_size=V3,ext_rcode=V4,version=V5,z=V6,data=V7};
-do_make_dns_rr_opt([{domain,V1}|L], _,V2,V3,V4,V5,V6,V7) ->
-    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
-do_make_dns_rr_opt([{type,V2}|L], V1,_,V3,V4,V5,V6,V7) ->
-    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
-do_make_dns_rr_opt([{udp_payload_size,V3}|L], V1,V2,_,V4,V5,V6,V7) ->
-    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
-do_make_dns_rr_opt([{ext_rcode,V4}|L], V1,V2,V3,_,V5,V6,V7) ->
-    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
-do_make_dns_rr_opt([{version,V5}|L], V1,V2,V3,V4,_,V6,V7) ->
-    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
-do_make_dns_rr_opt([{z,V6}|L], V1,V2,V3,V4,V5,_,V7) ->
-    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7);
-do_make_dns_rr_opt([{data,V7}|L], V1,V2,V3,V4,V5,V6,_) ->
-    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7).
+make_dns_rr_opt(#dns_rr_opt{domain=V1,type=V2,udp_payload_size=V3,ext_rcode=V4,version=V5,z=V6,data=V7,do=V8}, L) when is_list(L) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7,V8).
+do_make_dns_rr_opt([], V1,V2,V3,V4,V5,V6,V7,V8) ->
+    #dns_rr_opt{domain=V1,type=V2,udp_payload_size=V3,ext_rcode=V4,version=V5,z=V6,data=V7,do=V8};
+do_make_dns_rr_opt([{domain,V1}|L], _,V2,V3,V4,V5,V6,V7,V8) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7,V8);
+do_make_dns_rr_opt([{type,V2}|L], V1,_,V3,V4,V5,V6,V7,V8) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7,V8);
+do_make_dns_rr_opt([{udp_payload_size,V3}|L], V1,V2,_,V4,V5,V6,V7,V8) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7,V8);
+do_make_dns_rr_opt([{ext_rcode,V4}|L], V1,V2,V3,_,V5,V6,V7,V8) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7,V8);
+do_make_dns_rr_opt([{version,V5}|L], V1,V2,V3,V4,_,V6,V7,V8) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7,V8);
+do_make_dns_rr_opt([{z,V6}|L], V1,V2,V3,V4,V5,_,V7,V8) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7,V8);
+do_make_dns_rr_opt([{data,V7}|L], V1,V2,V3,V4,V5,V6,_,V8) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7,V8);
+do_make_dns_rr_opt([{do,V8}|L], V1,V2,V3,V4,V5,V6,V7,_) ->
+    do_make_dns_rr_opt(L, V1,V2,V3,V4,V5,V6,V7,V8).
 
 %% Update one field of #dns_rr_opt{}
 %%
@@ -260,7 +286,9 @@ make_dns_rr_opt(#dns_rr_opt{}=R, version, V5) ->
 make_dns_rr_opt(#dns_rr_opt{}=R, z, V6) ->
     R#dns_rr_opt{z=V6};
 make_dns_rr_opt(#dns_rr_opt{}=R, data, V7) ->
-    R#dns_rr_opt{data=V7}.
+    R#dns_rr_opt{data=V7};
+make_dns_rr_opt(#dns_rr_opt{}=R, do, V8) ->
+    R#dns_rr_opt{do=V8}.
 
 
 %%

--- a/src/mdns_lite_inet_int.hrl
+++ b/src/mdns_lite_inet_int.hrl
@@ -1,4 +1,4 @@
-%% SPDX-FileCopyrightText: Ericsson AB 1997-2021. All Rights Reserved.
+%% SPDX-FileCopyrightText: Ericsson AB 1997-2025. All Rights Reserved.
 %%
 %% SPDX-License-Identifier: Apache-2.0
 %%
@@ -17,6 +17,7 @@
 -define(INET_AF_LOOPBACK,     4). % Fake for LOOPBACK in any address family
 -define(INET_AF_LOCAL,        5). % For Unix Domain address family
 -define(INET_AF_UNDEFINED,    6). % For any unknown address family
+-define(INET_AF_LIST,         7). % List of addresses for sctp connectx
 
 %% type codes to open and gettype - INET_REQ_GETTYPE
 -define(INET_TYPE_STREAM,     1).
@@ -119,6 +120,9 @@
 -define(UDP_OPT_ADD_MEMBERSHIP,  14).
 -define(UDP_OPT_DROP_MEMBERSHIP, 15).
 -define(INET_OPT_IPV6_V6ONLY,    16).
+-define(INET_OPT_REUSEPORT,      17).
+-define(INET_OPT_REUSEPORT_LB,   18).
+-define(INET_OPT_EXCLUSIVEADDRUSE, 19).
 % "Local" options: codes start from 20:
 -define(INET_LOPT_BUFFER,        20).
 -define(INET_LOPT_HEADER,        21).
@@ -148,6 +152,9 @@
 -define(INET_OPT_TTL,             46).
 -define(INET_OPT_RECVTTL,         47).
 -define(TCP_OPT_NOPUSH,           48).
+-define(INET_LOPT_TCP_READ_AHEAD, 49).
+-define(INET_OPT_NON_BLOCK_SEND,  50).
+-define(INET_OPT_DEBUG,           99).
 % Specific SCTP options: separate range:
 -define(SCTP_OPT_RTOINFO,	 	100).
 -define(SCTP_OPT_ASSOCINFO,	 	101).
@@ -355,21 +362,26 @@
 	(?u8(X0) -
 	 (if (X0) > 127 -> 16#100; true -> 0 end))).
 
-%% macro for use in guard for checking ip address {A,B,C,D}
+%% macro for guards only that checks IP address {A,B,C,D}
+%% that returns true for an IP address, but returns false
+%% or crashes for other terms
 -define(ip(A,B,C,D),
 	(((A) bor (B) bor (C) bor (D)) band (bnot 16#ff)) =:= 0).
+%% d:o for IP address as one term
 -define(ip(Addr),
+        (tuple_size(Addr) =:= 4 andalso
         ?ip(element(1, (Addr)), element(2, (Addr)),
-            element(3, (Addr)), element(4, (Addr)))).
-
+             element(3, (Addr)), element(4, (Addr))))).
+%% d:o IPv6 address
 -define(ip6(A,B,C,D,E,F,G,H), 
 	(((A) bor (B) bor (C) bor (D) bor (E) bor (F) bor (G) bor (H)) 
 	 band (bnot 16#ffff)) =:= 0).
 -define(ip6(Addr),
-        ?ip6(element(1, (Addr)), element(2, (Addr)),
-             element(3, (Addr)), element(4, (Addr)),
-             element(5, (Addr)), element(6, (Addr)),
-             element(7, (Addr)), element(8, (Addr)))).
+        (tuple_size(Addr) =:= 8 andalso
+         ?ip6(element(1, (Addr)), element(2, (Addr)),
+              element(3, (Addr)), element(4, (Addr)),
+              element(5, (Addr)), element(6, (Addr)),
+              element(7, (Addr)), element(8, (Addr))))).
 
 -define(ether(A,B,C,D,E,F), 
 	(((A) bor (B) bor (C) bor (D) bor (E) bor (F)) 
@@ -421,8 +433,8 @@
 	  type   = seqpacket,
 	  opts   = [{mode,	  binary},
 		    {buffer,	  ?SCTP_DEF_BUFSZ},
-		    {sndbuf,	  ?SCTP_DEF_BUFSZ},
-		    {recbuf,	  1024},
+		    %% {sndbuf,	  ?SCTP_DEF_BUFSZ},
+		    %% {recbuf,	  1024},
 		    {sctp_events, undefined}%,
 		    %%{active,      true}
 		   ]


### PR DESCRIPTION
We started vendoring the DNS parser since OTP 24.1.2 fixed an mDNS issue, but we couldn't rely on 24.1.2 being available. Given that we haven't been testing on OTP 24 for a while, I think there's an argument to drop the vendored code completely.