### PR TITLE
Add service announcement on startup of responder

### DIFF
--- a/lib/mdns_lite/responder.ex
+++ b/lib/mdns_lite/responder.ex
@@ -48,11 +48,6 @@ defmodule MdnsLite.Responder do
           skip_udp: boolean()
         }
 
-  @spec announce_services(String.t(), :inet.ip_address()) :: :ok
-  def announce_services(iface_name, iface_address) do
-    Process.send(via_name({iface_name, iface_address}), :announce_services, [])
-  end
-
   ##############################################################################
   #   Public interface
   ##############################################################################

--- a/lib/mdns_lite/responder.ex
+++ b/lib/mdns_lite/responder.ex
@@ -48,6 +48,11 @@ defmodule MdnsLite.Responder do
           skip_udp: boolean()
         }
 
+  @spec announce_services(String.t(), :inet.ip_address()) :: :ok
+  def announce_services(iface_name, iface_address) do
+    Process.send(via_name({iface_name, iface_address}), :announce_services, [])
+  end
+
   ##############################################################################
   #   Public interface
   ##############################################################################
@@ -160,7 +165,7 @@ defmodule MdnsLite.Responder do
          :ok <- :socket.bind(udp, %{family: family, port: @mdns_port}),
          :ok <- add_membership(udp, interface, family) do
       new_state = %{state | udp: udp} |> process_receives()
-      {:noreply, new_state}
+      {:noreply, new_state, {:continue, :announce_services}}
     else
       {:error, reason} ->
         Logger.error("mdns_lite #{state.ifname}/#{inspect(state.ip)} failed: #{inspect(reason)}")
@@ -169,6 +174,13 @@ defmodule MdnsLite.Responder do
         # interface went away or its IP address changed.
         {:stop, :normal, state}
     end
+  end
+
+  def handle_continue(:announce_services, state) do
+    # TODO: The wait here is not necessary and needs to be removed
+    Process.send_after(self(), {:announce_services, 0}, 15000)
+
+    {:noreply, state}
   end
 
   @impl GenServer
@@ -207,6 +219,28 @@ defmodule MdnsLite.Responder do
         %{udp: udp, select_handle: select_handle} = state
       ) do
     {:noreply, process_receives(state)}
+  end
+
+  def handle_info({:announce_services, 3}, state) do
+    Logger.info("Services have been announced")
+    {:noreply, state}
+  end
+
+  def handle_info({:announce_services, count}, state) do
+    # For all services defined run a query to force sending unsolicidted announcement
+    TableServer.options()
+    |> Map.get(:services)
+    |> Enum.each(fn service ->
+      run_query(
+        dns_query(class: :in, domain: ~c"#{service.type}.local", type: :ptr),
+        dns_rec(header: dns_header()),
+        %{port: @mdns_port, addr: state.ip, family: :inet},
+        state
+      )
+    end)
+
+    Process.send_after(self(), {:announce_services, count + 1}, 1000)
+    {:noreply, state}
   end
 
   def handle_info(msg, state) do

--- a/lib/mdns_lite/responder_supervisor.ex
+++ b/lib/mdns_lite/responder_supervisor.ex
@@ -26,5 +26,6 @@ defmodule MdnsLite.ResponderSupervisor do
   @impl DynamicSupervisor
   def init(_init_arg) do
     DynamicSupervisor.init(strategy: :one_for_one)
+    # TODO: See Section 8.1 of standard
   end
 end

--- a/lib/mdns_lite/table/builder.ex
+++ b/lib/mdns_lite/table/builder.ex
@@ -16,6 +16,7 @@ defmodule MdnsLite.Table.Builder do
   @spec from_options(Options.t()) :: MdnsLite.Table.t()
   def from_options(%Options{} = config) do
     # TODO: This could be seriously simplified...
+    # CHRIS TODO: Announce service after they are all added
     []
     |> add_a_records(config)
     |> add_ptr_records(config)


### PR DESCRIPTION
Adding Service Announcements to be compliant with Section 8.3 of mDNS standard (https://datatracker.ietf.org/doc/html/rfc6762#section-8.3)

Excerpt: 
```
The second startup step is that the Multicast DNS responder MUST send
   an unsolicited Multicast DNS response containing, in the Answer
   Section, all of its newly registered resource records (both shared
   records, and unique records that have completed the probing step).
   If there are too many resource records to fit in a single packet,
   multiple packets should be used.
   ```
   
   Resolves #169 