### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # MdnsLite
 
 [![Hex version](https://img.shields.io/hexpm/v/mdns_lite.svg "Hex version")](https://hex.pm/packages/mdns_lite)
-[![API docs](https://img.shields.io/hexpm/v/mdns_lite.svg?label=hexdocs "API docs")](https://hexdocs.pm/mdns_lite/MdnsLite.html)
+[![API docs](https://img.shields.io/hexpm/v/mdns_lite.svg?label=hexdocs "API docs")](https://mdns-lite.hexdocs.pm/MdnsLite.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-networking/mdns_lite/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-networking/mdns_lite/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-networking/mdns_lite)](https://api.reuse.software/info/github.com/nerves-networking/mdns_lite)
 
@@ -78,7 +78,7 @@ needed to remove the service advertisement at runtime. If not specified,
 list of `"<key>=<value>"` strings that will be advertised in a TXT DNS record
 corresponding to the service.
 
-See [`MdnsLite.Options`](https://hexdocs.pm/mdns_lite/MdnsLite.Options.html) for
+See [`MdnsLite.Options`](https://mdns-lite.hexdocs.pm/MdnsLite.Options.html) for
 information about all application environment options.
 
 It's possible to change the advertised hostnames, instance names and services at

--- a/lib/mix/tasks/mdns_lite.install.ex
+++ b/lib/mix/tasks/mdns_lite.install.ex
@@ -88,7 +88,7 @@ if Code.ensure_loaded?(Igniter) do
         |> igniter_nerves("config.exs")
         |> Igniter.add_notice("""
         The defaults for `mix mdns_lite.install` are intended for Nerves projects.  Please visit
-        its README at https://hexdocs.pm/mdns_lite/readme.html for an overview of usage.
+        its README at https://mdns-lite.hexdocs.pm/readme.html for an overview of usage.
         """)
       end
     end
@@ -131,7 +131,7 @@ else
       Mix.shell().error("""
       The task 'mdns_lite.install' requires igniter. Please install igniter and try again.
 
-      For more information, see: https://hexdocs.pm/igniter/readme.html#installation
+      For more information, see: https://igniter.hexdocs.pm/readme.html#installation
       """)
 
       exit({:shutdown, 1})

--- a/test/mdns_lite/mix/tasks/install_test.exs
+++ b/test/mdns_lite/mix/tasks/install_test.exs
@@ -31,7 +31,7 @@ defmodule MdnsLite.Mix.Tasks.InstallTest do
     """)
     |> assert_has_notice("""
     The defaults for `mix mdns_lite.install` are intended for Nerves projects.  Please visit
-    its README at https://hexdocs.pm/mdns_lite/readme.html for an overview of usage.
+    its README at https://mdns-lite.hexdocs.pm/readme.html for an overview of usage.
     """)
   end
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://mdns-lite.hexdocs.pm/MdnsLite.html): Status 404
❌ Verification failed for https://mdns-lite.hexdocs.pm/MdnsLite.Options.html): Status 404
⚠️ Verification finished: 2 success, 2 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>